### PR TITLE
mark /dist as excluded to prevent scanning

### DIFF
--- a/.idea/pytools.iml
+++ b/.idea/pytools.iml
@@ -4,6 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="facet-develop" jdkType="Python SDK" />


### PR DESCRIPTION
Minor change - avoids PyCharm scanning /dist, which is used for the output/working files of conda-build