### PR TITLE
CONDA: update conda build path to replace spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-export CONDA_BLD_PATH=dist/conda
 FACET_PATH := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+FACET_PATH := $(shell echo "${FACET_PATH}" | sed -e 's/ //g')
+export CONDA_BLD_PATH=$(FACET_PATH)/pytools/dist/conda
+
 
 help:
 	@echo Usage: make package


### PR DESCRIPTION
**This PR**
- Updates conda build and facet path as discussed with @joerg-schneider 

**Run instructions**
- activate the `facet-develop` environment (or install it) 
- run `make package` from inside the `pytools/` root directory