### PR TITLE
CI/CD: specify py_modules for pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     # the `py_modules` argument instead as follows, which will expect a file
     # called `my_module.py` to exist:
     #
-    #   py_modules=["my_module"],
+    py_modules=["pytools"],
     #
     packages=find_packages(where="src"),
     package_dir={"": "src"},


### PR DESCRIPTION
**This PR**: 
* Updates the `setup.py` by specifying the `py_modules` option, in order to be able to import the package as `pytools` rather than `gamma-pytools`, while the pip installation remains `pip install gamma-pytools`
* This is required to locally install the package dependencies for CI/CD testing

**Run instructions**
1. Create a new test env which does not have `pytools` installed: `conda create --name test python=3.7`
2. `conda activate test`
3. Run `pip install -e .` from inside the `pytools` project root directory to test the local pip installation
4. Open a the python console inside that window and `import pytools`, which should succeed
5. Clean up with `conda env remove -n test`