### PR TITLE
Update GitHub Org in CI/CD Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,8 @@ resources:
   repositories:
     - repository: facet
       type: github
-      endpoint: konst-int-i # todo - update to final github org
-      name: konst-int-i/facet # todo - update to final github org
+      endpoint: BCG-Gamma
+      name: BCG-Gamma/facet
       ref: develop # todo - update to stable release
 
 trigger:


### PR DESCRIPTION
**This PR**
* Updates the repos in the `azure-pipelines.yml` to the new `BCG-Gamma` org

**Run instructions**
* When triggering a run for this branch, we should see the [Azure pipelines](https://dev.azure.com/gamma-facet/facet) succeeding.