### PR TITLE
use GAMMA FACET colours as the default colour scheme for matplot charts

### DIFF
--- a/src/pytools/viz/_matplot.py
+++ b/src/pytools/viz/_matplot.py
@@ -150,9 +150,7 @@ class ColorbarMatplotStyle(MatplotStyle, metaclass=ABCMeta):
     """
 
     DEFAULT_COLORMAP = LinearSegmentedColormap.from_list(
-        "facet",
-        [(0.0, "#1F465F"), (0.25, "#075a5b"), (0.75, "#40fba1"), (1.0, "#98FBCD")],
-        gamma=0.78,
+        "facet", ["#3d3a40", "#295e7e", "#30c1d7", "#43fda2"]
     )
 
     def __init__(


### PR DESCRIPTION
<img width="424" alt="image" src="https://user-images.githubusercontent.com/30187284/92009078-42a8ac00-ed48-11ea-8a41-1239fef1c4c2.png">

We are currently reviewing the colour scheme with Andy, with the aim of maximising contrast along the colour scale. 