### PR TITLE
Add full Sphinx configuration to global scope in method set_config()

### DIFF
--- a/sphinx/source/conf_base.py
+++ b/sphinx/source/conf_base.py
@@ -56,6 +56,11 @@ def set_config(
             sys.path.insert(0, module_path)
             _log.info(f"added `{module_path}` to python paths")
 
+    # Update global variables
+    globals_.update(
+        (k, v) for k, v in globals().items() if not (k.startswith("_") or k in globals_)
+    )
+
 
 _log.info(f"sys.path = {sys.path}")
 


### PR DESCRIPTION
This PR
- Adds the logic to update the global variables (config variables) within the set_config function that is invoked across repos

Running `python make.py html` from any repo's sphinx directory should now produce as expected documentation