### PR TITLE
rename conda-build to condabuild in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # set the build name
 name: $[ variables['branchName'] ]
 
-# RUN TESTS AND FULL CONDA BUILD MATRIX EVERY NIGHT AT 4AM
+# run tests and full conda build matrix every night at 4am
 schedules:
 - cron: "0 4 * * *"
   displayName: Nightly full build


### PR DESCRIPTION
The azure pipeline configuration refers to the conda build directory, so we have to update these references to the new name `condabuild`