### PR TITLE
CI/CD: define trigger and pr sections for pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,12 @@
+trigger:
+  - master
+  - develop
+  - release/*
+
+pr:
+  - master
+  - develop
+
 # set the build name
 name: $[ variables['branchName'] ]
 


### PR DESCRIPTION
**This PR...**
aims to make the triggers for pipeline runs (excl. scheduled builds) specific. At the moment, all branches are built on push, with the addition of merge commits created by open PRs. Hence, currently we build all commits of open PRs twice:
<img width="1157" alt="grafik" src="https://user-images.githubusercontent.com/46053259/96706706-38457e80-1397-11eb-9139-2bca33912f21.png">

(once as "Individual CI" and once for "PR automated").

I am proposing this setting as part of the pipeline declaration file:

```
trigger:
  - master
  - develop
  - release/*

pr:
  - master
  - develop
  - release/*
```

This means, all direct pushes/merges to the core branches cause builds. Additionally, all PRs that touch these cause builds.

The main side implication is, individual branches still in development or kept for other reasons, will not be built, until a PR is open. As this should not be needed, the change will help to cut required resources roughly in half avoiding the duplicated builds mentioned below.

@j-ittner @rkdy as discussed.

On todo to keep in mind for the __final__ build pipeline: Once we have included the Conda upload step to publish, we should make it indempotent. I.e. on second run if version X was already published, do not fail but skip this skep. In that case, we can run the pipeline multiple times without errors for master/release/..