### PR TITLE
Correct signature of ParallelizableMixin._delayed

### DIFF
--- a/src/pytools/parallelization/_parallelization.py
+++ b/src/pytools/parallelization/_parallelization.py
@@ -2,7 +2,7 @@
 Core implementation of :mod:`pytools.parallelization`
 """
 import logging
-from typing import Callable, Dict, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
 
 import joblib
 


### PR DESCRIPTION
The second and third element of the tuple returned by method `ParallelizableMixin._delayed` are the `args` and `kwargs` of the original function call. In Python these are represented by a `tuple` and a `dict`, respectively. This PR adjusts the function signature accordingly.