### PR TITLE
Remove "The" from BCG in the copyright

### DIFF
--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -72,7 +72,7 @@ _log.info(f"sys.path = {sys.path}")
 # -- Project information -----------------------------------------------------
 
 project = "pytools"
-copyright = "2020, The Boston Consulting Group (BCG)"
+copyright = "2020, Boston Consulting Group (BCG)"
 author = "FACET Team"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Hotfix: Removes the "The" from BCG. This copyright notice appears in all the repos above "Created using Sphinx"

![image](https://user-images.githubusercontent.com/25201990/97112595-30f6db80-16dd-11eb-862a-e4d954df32a4.png)
