### PR TITLE
build: bugfix: bash env variables can't use dash -> change to underscore

### DIFF
--- a/make.py
+++ b/make.py
@@ -141,7 +141,8 @@ def expose_deps(project: str, build_system: str, dependency_type: str) -> None:
             )
 
     for d_name, d_version in dependencies_to_expose.items():
-        env_var_key = f"FACET_V_{d_name}".upper().strip()
+        # bash ENV variables can not use dash, replace it to _
+        env_var_key = f"FACET_V_{d_name.replace('-','_')}".upper().strip()
         env_var_value = d_version.strip()
         print(f"Exposing: '{env_var_key}' as: '{env_var_value}'")
         os.environ[env_var_key] = env_var_value


### PR DESCRIPTION
This bugfix PR changes how make.py exposes Python dependencies as ENV variables – it now correctly substitutes dash with underscore, as dash can't be used there in a BASH shell.

Mandatory to get https://github.com/BCG-Gamma/sklearndf/pull/54 running