### PR TITLE
Warn on spaces in build path and allow override using ENV variable

### DIFF
--- a/make.py
+++ b/make.py
@@ -10,9 +10,9 @@ import pathlib
 import shutil
 import subprocess
 import sys
+import warnings
 from glob import glob
 from typing import Any, Dict, List
-from urllib.parse import quote
 from urllib.request import pathname2url
 
 import toml
@@ -21,7 +21,24 @@ ALL_PROJECTS_QUALIFIER = "all"
 
 CWD = os.getcwd()
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
-FACET_PATH = os.path.abspath(os.path.join(SCRIPT_DIR, os.pardir))
+
+FACET_PATH_ENV = "FACET_PATH"
+FACET_PATH_URI_ENV = "FACET_PATH_URI"
+FACET_BUILD_PKG_VERSION_ENV = "FACET_BUILD_{project}_VERSION"
+CONDA_BUILD_PATH_ENV = "CONDA_BLD_PATH"
+
+if FACET_PATH_ENV in os.environ and os.environ[FACET_PATH_ENV] != "":
+    FACET_PATH = os.environ[FACET_PATH_ENV]
+else:
+    FACET_PATH = os.path.abspath(os.path.join(SCRIPT_DIR, os.pardir))
+
+if " " in FACET_PATH:
+    warnings.warn(
+        f"The build base path '{FACET_PATH}' contains spaces – this causes issues "
+        f"with conda-build. Consider to set a different path using the "
+        f"environment variable {FACET_PATH_ENV} ahead of running make.py"
+    )
+
 KNOWN_COMMANDS = "build"
 
 KNOWN_PROJECTS = ("pytools", "sklearndf", "facet")
@@ -36,10 +53,6 @@ MAX_DEPS = "max"
 UNCONSTRAINED_DEPS = "unconstrained"
 KNOWN_DEPENDENCY_TYPES = (DEFAULT_DEPS, MIN_DEPS, MAX_DEPS, UNCONSTRAINED_DEPS)
 
-FACET_PATH_ENV = "FACET_PATH"
-FACET_PATH_URI_ENV = "FACET_PATH_URI"
-FACET_BUILD_PKG_VERSION_ENV = "FACET_BUILD_{project}_VERSION"
-CONDA_BUILD_PATH_ENV = "CONDA_BLD_PATH"
 CONDA_BUILD_PATH_SUFFIX = os.path.join("dist", "conda")
 TOX_BUILD_PATH_SUFFIX = os.path.join("dist", "tox")
 
@@ -177,7 +190,7 @@ def set_up(project: str, build_system: str, dependency_type: str) -> None:
     Set up for a build – set FACET_PATH (parent folder of all projects) and clean.
     """
     os.environ[FACET_PATH_ENV] = FACET_PATH
-    os.environ[FACET_PATH_URI_ENV] = f"file://{quote(pathname2url(FACET_PATH))}"
+    os.environ[FACET_PATH_URI_ENV] = f"file://{pathname2url(FACET_PATH)}"
     clean(project, build_system)
     expose_deps(project, build_system, dependency_type)
     pkg_version = get_package_version(project)


### PR DESCRIPTION
This PR should make the file:// URI urlsafe, to protect against whitespaces, non-ascii or similar characters in the path up to the facet git repos.