### PR TITLE
Release pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -336,7 +336,7 @@ stages:
   # - add release tag
   # - create GitHub release with changelog
   # - upload conda and pip packages as artifacts to GitHub
-  - stage: release
+  - stage:
     displayName: 'Release'
     dependsOn: conda_tox_build
 
@@ -401,7 +401,6 @@ stages:
   # render docs and publish to GitHub Pages
   - stage:
     displayName: 'Docs'
-    dependsOn: release
 
     variables:
     - group: github_ssh


### PR DESCRIPTION
This PR extends the Azure Pipelines configuration to help automate releases:
- Uploads build artifacts (conda and pip packages) to Azure DevOps on release and master branches
- Triggers GitHub release on master branch (i.e., upon merging the release branch)
    - Tags release commit with version number as specified in `src/__init__.py`
    - Creates GitHub release page for new version
    - Pre-fills GitHub release title and description, incl. changelog based on commits since last release (can be manually edited to be more succinct afterwards - **open point**: create release notes file that can be referred here?)
    - Attaches build artifacts (conda and pip packages) to GitHub release

See screenshot below for an impression of how the release page will look.

The current release workflow:
1. Create new release branch from `develop`, with PR to `master`
2. Automatically run all conda/pip build tests via Azure Pipelines, triggering automatic upload of artifacts to Azure DevOps
3. If all is OK, merge PR to `master`, triggering the release pipeline added here, as described above
4. Manually upload build artifacts to conda/PyPI (**open point**: include this in Azure pipeline in the future?)
5. Merge any changes from release branch also back to `develop`
6. Bump up version in `src/__init__.py` on `develop` to start work towards next release

![image](https://user-images.githubusercontent.com/22475572/98707019-dc5f8b80-237f-11eb-9add-c5fdbc5fe58c.png)