### PR TITLE
Improve docs deployment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -472,6 +472,7 @@ stages:
             targetType: 'inline'
             script: |
               set -e
+              eval "$(conda shell.bash hook)"
               cp -r $(Build.ArtifactStagingDirectory)/old_docs/docs .
               echo "Current docs contents:"
               tree docs


### PR DESCRIPTION
This PR improves the docs deployment:
- Content on deployment branch `github-pages` reduced to only contain `docs` folder and no code (besides `azure-pipelines.yml` with one-liner to disable CI for the branch)
- `python sphinx/make.py prepare_docs_deployment` script run from branch that triggers the deployment, instead of using code on `github-pages` branch that would have to be manually updated regularly

Additionally, it fixes the following:
- Variable `branchName` adjusted so that for PRs it's the source (current) branch, rather than the target branch (e.g., `develop` for this PR)
- Build test is run only when diff is detected in the build config compared to the prior commit. Formerly, this was triggered when there was a diff to the target branch, resulting in potentially many unnecessary builds