### PR TITLE
Bugfix: Repair docs update when old version is present

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -411,7 +411,7 @@ stages:
     jobs:
     - job:
       displayName: 'Build and publish docs'
-      # condition: eq(variables.master_or_release, 'True')
+      condition: eq(variables.master_or_release, 'True')
 
       pool:
           vmImage: 'ubuntu-latest'


### PR DESCRIPTION
This PR fixes the failing Azure Pipeline when an old docs version is already present on the `github-pages` branch:
- Removes the newly built docs before checking out `github-pages` to avoid checkout error message ("files would be overwritten ...")
- Reinstates condition that docs deployment should only happen on the release of a new version (i.e., on the `master` branch)