### PR TITLE
add azure badge links and update conda install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ utilities for reuse, including:
 - Parallelization based on the joblib package
 - A lean MVC framework for rendering basic visualizations in different styles, e.g., as Matplotlib charts or as plain text
 
-|pypi| |conda| |azure_devops_master_ci| |code_cov|
+|pypi| |conda| |azure_build| |azure_code_cov|
 |python_versions| |code_style| |made_with_sphinx_doc| |License_badge|
 
 Installation
@@ -25,7 +25,7 @@ Anaconda
 
 .. code-block:: RST
 
-    conda install -c bcg_gamma gamma-pytools
+    conda install gamma-pytools -c bcg_gamma -c conda-forge
 
 Pip
 ~~~~~~~~~~~~~~~~~~~~~
@@ -80,11 +80,11 @@ or have a look at
 .. |pypi| image:: https://badge.fury.io/py/gamma-pytools.svg
     :target: https://pypi.org/project/gamma-pytools/
 
-.. |azure_devops_master_ci| image:: https://
-    :target: https://
+.. |azure_build| image:: https://dev.azure.com/gamma-facet/facet/_apis/build/status/BCG-Gamma.pytools?branchName=develop
+   :target: https://dev.azure.com/gamma-facet/facet/_build?definitionId=9&_a=summary
 
-.. |code_cov| image:: https://
-    :target: https://
+.. |azure_code_cov| image:: https://img.shields.io/azure-devops/coverage/gamma-facet/facet/_build?definitionId=9.svg
+   :target: https://dev.azure.com/gamma-facet/facet/_build?definitionId=9&_a=summary
 
 .. |python_versions| image:: https://img.shields.io/badge/python-3.7|3.8-blue.svg
     :target: https://www.python.org/downloads/release/python-380/


### PR DESCRIPTION
This PR adds azure badge links for build and coverage and updates the conda install instructions. Note the azure gitbadges will not render correctly until the Azure pipelines are made public.