### PR TITLE
Improve release pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,11 +181,11 @@ stages:
     jobs:
     - job:
       displayName: 'single'
-      # condition: >
-      #  and(
-      #  ne(variables.master_or_release, 'True'),
-      #  ne(stageDependencies.detect_build_config_changes.checkout_and_diff.outputs['diff.conda_build_config_changed'], '0')
-      #  )
+      condition: >
+        and(
+        ne(variables.master_or_release, 'True'),
+        ne(stageDependencies.detect_build_config_changes.checkout_and_diff.outputs['diff.conda_build_config_changed'], '0')
+        )
 
       pool:
           vmImage: 'ubuntu-latest'
@@ -195,11 +195,11 @@ stages:
           maximum_dependencies_conda:
             FACET_V_PYTHON_BUILD: '=3.8.*'
             BUILD_SYSTEM: 'conda'
-            PKG_DEPENDENCIES: 'default'
+            PKG_DEPENDENCIES: 'max'
           maximum_dependencies_tox:
             FACET_V_PYTHON_BUILD: '=3.8.*'
             BUILD_SYSTEM: 'tox'
-            PKG_DEPENDENCIES: 'default'
+            PKG_DEPENDENCIES: 'max'
       
       steps:
         - task: UsePythonVersion@0
@@ -346,7 +346,7 @@ stages:
     jobs:
       - job:
         displayName: 'Release'
-        # condition: eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'master')
+        condition: eq(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'master')
 
         steps:
           - task: UsePythonVersion@0
@@ -385,10 +385,10 @@ stages:
 
           - task: GitHubRelease@1
             inputs:
-              gitHubConnection: BCG-Gamma-test
-              repositoryName: rkdy/pytools # $(Build.Repository.Name)
+              gitHubConnection: github_release
+              repositoryName: $(Build.Repository.Name)
               action: create
-              target: develop # $(Build.SourceVersion)
+              target: $(Build.SourceVersion)
               tagSource: userSpecifiedTag
               tag: $(current_version)
               title: pytools $(current_version)


### PR DESCRIPTION
This PR adds improvements made in the release pipeline for `sklearndf` and `facet` (that were added in the process of adapting the `pytools` one).

Changes:
- Use `get_package_version` function instead of workaround that only applies to `pytools`
- Fix bug from extra quotation mark when getting package version
- Use pipeline step specifying Python version used