### PR TITLE
Bugfix: Use additional bcg_gamma channel in release notes instructions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -402,7 +402,7 @@ stages:
 
                 Your conda package can be upgraded by running
 
-                    conda install -c conda-forge gamma-pytools
+                    conda install -c conda-forge -c bcg_gamma gamma-pytools
 
               isDraft: false
               isPreRelease: $(is_prerelease)


### PR DESCRIPTION
This PR adds the `bcg_gamma` channel for conda upgrade instructions in release notes when releasing via Azure Pipelines on GitHub (can be removed once we fully move to `conda-forge`).