### PR TITLE
replace 3rd party docstrings with a reference to the 3rd party module

### DIFF
--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, Iterable, Optional
 
 from sphinx.application import Sphinx
 
+from pytools.sphinx import Replace3rdPartyDoc
+
 logging.basicConfig(level=logging.INFO)
 _log = logging.getLogger(name=__name__)
 
@@ -205,6 +207,8 @@ def setup(app: Sphinx) -> None:
     ).connect(app=app, priority=100000)
 
     SkipIndirectImports().connect(app=app)
+
+    Replace3rdPartyDoc().connect(app=app)
 
     _add_custom_css_and_js(app=app)
 


### PR DESCRIPTION
This PR introduces a new Sphinx callback class to replace 3rd party docstrings with a reference to the 3rd party documentation.

This is necessary for methods and attributes inherited from 3rd party packages, as these might use an incompatible format for docstrings.