### PR TITLE
rename type variables for methods' "self" arguments to T_Self

### DIFF
--- a/src/pytools/fit/_fit.py
+++ b/src/pytools/fit/_fit.py
@@ -20,7 +20,7 @@ __all__ = ["NotFittedError", "FittableMixin"]
 # Type variables
 #
 
-T = TypeVar("T")
+T_Self = TypeVar("T_Self")
 T_Data = TypeVar("T_Data")
 
 
@@ -48,7 +48,7 @@ class FittableMixin(Generic[T_Data], metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def fit(self: T, _x: T_Data, **fit_params) -> T:
+    def fit(self: T_Self, _x: T_Data, **fit_params) -> T_Self:
         """
         Fit this object to the given data.
 


### PR DESCRIPTION
Use type variable `T_Self` in constructs of the form

``` python
def a_method(self: T_Self, …) -> T_Self:
    …
```

This leads to a more self-explanatory return type in the Sphinx docstring.