### PR TITLE
set the default range of the PercentageMatrix colorbar to [0.0,1.0]

### DIFF
--- a/src/pytools/viz/matrix/_matrix.py
+++ b/src/pytools/viz/matrix/_matrix.py
@@ -289,7 +289,11 @@ class PercentageMatrixMatplotStyle(MatrixMatplotStyle):
         super().__init__(
             ax=ax,
             colors=colors,
-            colormap_normalize=colormap_normalize,
+            colormap_normalize=(
+                colormap_normalize
+                if colormap_normalize
+                else Normalize(vmin=0.0, vmax=1.0)
+            ),
             max_ticks=max_ticks,
             colorbar_major_formatter=PercentageFormatter(),
             colorbar_minor_formatter=None,


### PR DESCRIPTION
This PR ensures that the color bar of matplot `PercentageMatrix` plots always ranges from 0.0 to 1.0, even if the matrix data is within a smaller range. This ensures consistent colours across percentage matrices.