### PR TITLE
Improve handling of 3rd party module references in Sphinx documentation

### DIFF
--- a/sphinx/source/_static_base/css/gamma.css
+++ b/sphinx/source/_static_base/css/gamma.css
@@ -17,11 +17,15 @@ code {
     padding-right: 1pt;
 }
 
+.bd-content .longtable.table {
+    display: table;
+}
+
 .longtable.table {
     width: 100%;
 }
 
-.longtable.table td, .table th {
+.longtable.table td, .longtable.table th {
     padding: .25rem;
     vertical-align: top;
     border-top: 1px solid #DEE2E6;

--- a/src/pytools/sphinx/_sphinx.py
+++ b/src/pytools/sphinx/_sphinx.py
@@ -25,7 +25,7 @@ from typing import (
 
 import typing_inspect
 
-from pytools.api import AllTracker, get_generic_bases, inheritdoc
+from pytools.api import AllTracker, get_generic_bases, inheritdoc, public_module_prefix
 
 log = logging.getLogger(__name__)
 
@@ -781,9 +781,10 @@ class Replace3rdPartyDoc(AutodocProcessDocstring):
             # replace 3rd party docstring with cross-reference
 
             directive = Replace3rdPartyDoc.__RST_DIRECTIVE.get(what, what)
+            public_module = public_module_prefix(obj_module)
 
             del lines[:]
-            lines.append(f"See :{directive}:`{obj_module}.{obj.__qualname__}`")
+            lines.append(f"See :{directive}:`{public_module}.{obj.__qualname__}`")
 
     @staticmethod
     def __root_package(name: str) -> str:


### PR DESCRIPTION
- add function `pytools.api.public_module_prefix()`
- only use the public module prefix in doc references to 3rd party modules