### PR TITLE
DOC: disable extended timeout for nbsphinx doc build

### DIFF
--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -114,7 +114,6 @@ autodoc_default_options = {
 }
 
 nbsphinx_allow_errors = True
-nbsphinx_timeout = 60 * 15  # 15 minutes due to tutorial/model notebook
 
 # add intersphinx mapping
 intersphinx_mapping = {


### PR DESCRIPTION
We do not need the extended timeout any more as tutorial notebooks are not being run while building the documentation.