### PR TITLE
DOC: remove flow package from intersphinx list

### DIFF
--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -133,7 +133,6 @@ intersphinx_mapping = {
     "pytools": ("https://bcg-gamma.github.io/pytools/", None),
     "sklearndf": ("https://bcg-gamma.github.io/sklearndf/", None),
     "facet": ("https://bcg-gamma.github.io/facet/", None),
-    "flow": ("https://bcg-gamma.github.io/flow/", None),
 }
 
 intersphinx_collapsible_submodules = {


### PR DESCRIPTION
Other GAMMA packages are unlikely to depend on _flow_, so we do not have to share its documentation via _intersphinx_.