### PR TITLE
FIX: drop support for joblib v0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
     "pandas >= 0.24,<1.2",
     "numpy  >= 1.16,<1.20",
     "matplotlib >= 3.0,<3.4",
-    "joblib >= 0.13,<1.17",
+    "joblib >= 0.14,<1.1",
     "scipy  >= 1.2,<1.6",
     "typing_inspect >= 0.4",
     "pyyaml >= 5.0"
@@ -70,7 +70,7 @@ pandas      =  "=0.24.*"
 matplotlib  =  "=3.0.*"
 numpy       =  "=1.16.*"
 scipy       =  "=1.2.*"
-joblib      =  "=0.13.*"
+joblib      =  "=0.14.*"
 
 [build.matrix.max]
 python      =  "=3.8.*"
@@ -78,7 +78,7 @@ pandas      =  "=1.1.*"
 matplotlib  =  "=3.3.*"
 numpy       =  "=1.19.*"
 scipy       =  "=1.5.*"
-joblib      =  "=0.16.*"
+joblib      =  "=1.0.*"
 
 [build.matrix.unconstrained]
 python      =  ">=3.6,<4"
@@ -86,7 +86,7 @@ pandas      =  ">=0.24"
 matplotlib  =  ">=3.0"
 numpy       =  ">=1.16"
 scipy       =  ">=1.2"
-joblib      =  ">=0.13"
+joblib      =  ">=0.14"
 
 [tool.black]
 # quiet = "True"


### PR DESCRIPTION
joblib v0.13 raised an exception while pickling objects for FACET simulations; this is working with Joblib 0.14 and later.