### PR TITLE
BUILD: add bcg_gamma to conda channels in make.py

### DIFF
--- a/make.py
+++ b/make.py
@@ -246,7 +246,10 @@ def conda_build(project: str, dependency_type: str) -> None:
 
     print(f"Building: {project}. Build path: {build_path}")
     os.makedirs(build_path, exist_ok=True)
-    build_cmd = f"conda-build -c conda-forge {' '.join(local_channels)} {recipe_path}"
+    build_cmd = (
+        "conda-build -c conda-forge -c bcg_gamma "
+        f"{' '.join(local_channels)} {recipe_path}"
+    )
     print(f"Build Command: {build_cmd}")
     subprocess.run(args=build_cmd, shell=True, check=True)
 


### PR DESCRIPTION
This will allow us to test against older, published FACET packages living on Conda in matrix tests, e.g., test `sklearndf 1.1.*` with `pytools 1.0.*`