### PR TITLE
BUILD: add support for numpy 1.20

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - m2r = 0.2.*
   - matplotlib = 3.3.*
   - nbsphinx = 0.7.*
-  - numpy = 1.19.*
+  - numpy = 1.20.*
   - pandas = 1.1.*
   - pip = 20.*
   - pluggy = 0.13.*

--- a/environment.yml
+++ b/environment.yml
@@ -4,21 +4,21 @@ channels:
 dependencies:
   - black = 20.8b1
   - boruta_py = 0.3.*
-  - conda-build
-  - conda-verify
-  - docutils
+  - conda-build = 3.20.*
+  - conda-verify = 3.1.*
+  - docutils = 0.16.*
   - flit = 3.0
   - flake8 = 3.8.*
   - flake8-comprehensions = 3.2.*
   - isort = 5.5.*
-  - joblib = 0.16.*
+  - joblib = 1.0.*
   - jupyter >= 1.0
   - lightgbm = 3.0.*
   - m2r = 0.2.*
   - matplotlib = 3.3.*
   - nbsphinx = 0.7.*
   - numpy = 1.20.*
-  - pandas = 1.1.*
+  - pandas = 1.2.*
   - pip = 20.*
   - pluggy = 0.13.*
   - pre-commit = 2.7.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = "Apache Software License v2.0"
 requires = [
     "joblib         >=0.13,<1.1",
     "matplotlib     >=3.0,<3.4",
-    "numpy          >=1.16,<1.20",
+    "numpy          >=1.16,<1.21",
     "pandas         >=0.24,<1.2",
     "scipy          >=1.2,<1.6",
     "typing_inspect >=0.4,<0.7",
@@ -76,7 +76,7 @@ typing_inspect = "=0.4"
 [build.matrix.max]
 joblib         = "=1.0.*"
 matplotlib     = "=3.3.*"
-numpy          = "=1.19.*"
+numpy          = "=1.20.*"
 packaging      = ">=20"
 pandas         = "=1.1.*"
 python         = "=3.8.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
     "joblib         >=0.13,<1.1",
     "matplotlib     >=3.0,<3.4",
     "numpy          >=1.16,<1.21",
-    "pandas         >=0.24,<1.2",
+    "pandas         >=0.24,<1.3",
     "scipy          >=1.2,<1.6",
     "typing_inspect >=0.4,<0.7",
 ]
@@ -74,14 +74,14 @@ scipy          = "=1.2.*"
 typing_inspect = "=0.4"
 
 [build.matrix.max]
-joblib         = "=1.0.*"
-matplotlib     = "=3.3.*"
-numpy          = "=1.20.*"
+joblib         = "<1.1"
+matplotlib     = "<3.4"
+numpy          = "<1.21"
 packaging      = ">=20"
-pandas         = "=1.1.*"
+pandas         = "<1.3"
 python         = "=3.8.*"
-scipy          = "=1.5.*"
-typing_inspect = "=0.6"
+scipy          = "<1.6"
+typing_inspect = "<0.7"
 
 [tool.black]
 # quiet = "True"


### PR DESCRIPTION
This might also resolve a current issue with `pip`, where `pip` appears to be unable to reconcile an unconstrained `numpy` requirement of `shap` with `facet`'s current `numpy` <1.20 requirement.