### PR TITLE
BUILD: revise veracode scan naming

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -352,7 +352,7 @@ stages:
               ConnectionDetailsSelection: 'Endpoint'
               AnalysisService: 'veracode'
               veracodeAppProfile: 'FACET'
-              version: 'Fixed_name'
+              version: '$(BuildID)'
               filepath: '$(System.DefaultWorkingDirectory)/static_scan'
               sandboxName: 'pytools'
               createSandBox: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -334,7 +334,7 @@ stages:
     jobs:
       - job:
         displayName: 'Veracode check'
-        condition: eq(variables['Build.Reason'], 'Schedule')
+        #condition: eq(variables['Build.Reason'], 'Schedule')
 
         steps:
           - task: Bash@3
@@ -352,7 +352,7 @@ stages:
               ConnectionDetailsSelection: 'Endpoint'
               AnalysisService: 'veracode'
               veracodeAppProfile: 'FACET'
-              version: '$(Build.BuildNumber)'
+              version: 'Fixed_name'
               filepath: '$(System.DefaultWorkingDirectory)/static_scan'
               sandboxName: 'pytools'
               createSandBox: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -352,7 +352,7 @@ stages:
               ConnectionDetailsSelection: 'Endpoint'
               AnalysisService: 'veracode'
               veracodeAppProfile: 'FACET'
-              version: '$(BuildID)'
+              version: '$(Build.BuildID)'
               filepath: '$(System.DefaultWorkingDirectory)/static_scan'
               sandboxName: 'pytools'
               createSandBox: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -334,7 +334,7 @@ stages:
     jobs:
       - job:
         displayName: 'Veracode check'
-        #condition: eq(variables['Build.Reason'], 'Schedule')
+        condition: eq(variables['Build.Reason'], 'Schedule')
 
         steps:
           - task: Bash@3


### PR DESCRIPTION
PR updates the version in the veracode step of the pipeline to pass the `BuildID` to ensure a scan is performed for each new pipeline run.