### PR TITLE
BUILD: optimize conda build config

### DIFF
--- a/condabuild/meta.yaml
+++ b/condabuild/meta.yaml
@@ -13,6 +13,7 @@ requirements:
   host:
     - pip>=20.*
     - python {{ environ.get('FACET_V_PYTHON', '=3.8.*') }}
+    - numpy {{ environ.get('FACET_V_NUMPY', '>=1.11.*') }}
     - flit>=3.0.*
   run:
     - joblib{{ environ.get('FACET_V_JOBLIB') }}


### PR DESCRIPTION
- specify numpy host version to prevent conda warning message
