### PR TITLE
BUILD: set version to 1.0.2rc0

### DIFF
--- a/sphinx/source/faqs.rst
+++ b/sphinx/source/faqs.rst
@@ -34,5 +34,5 @@ Bibtex entry::
      title={pytools},
      author={Pytools Team at BCG Gamma},
      year={2021},
-     note={Python package version 1.0.2}
+     note={Python package version 1.0.2rc0}
      }

--- a/src/pytools/__init__.py
+++ b/src/pytools/__init__.py
@@ -1,4 +1,4 @@
 """
 A collection of Python extensions and tools used in BCG GAMMA's open-source libraries.
 """
-__version__ = "1.0.2"
+__version__ = "1.0.2rc0"


### PR DESCRIPTION
To prepare the 1.0.2 release, I propose we start off with a release candidate. This PR sets the version of pytools to `1.0.2rc0`.