### PR TITLE
BUILD: prepare pipeline for publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,7 +364,7 @@ stages:
               importResults: false
               failBuildOnPolicyFail: false
 
-  - stage:
+  - stage: check_release
     displayName: 'Check Release Version'
     dependsOn: conda_tox_build
 
@@ -429,7 +429,7 @@ stages:
   # - upload conda and pip packages as artifacts to GitHub
   - stage:
     displayName: 'Release'
-    dependsOn: conda_tox_build
+    dependsOn: check_release
     variables:
     - group: artifact_publication
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -480,34 +480,34 @@ stages:
           - script: |
               set -e
               cd $(System.DefaultWorkingDirectory)
-              pip install flit
-              flit publish
-              echo "##vso[task.setvariable variable=pypi_published]True"
-            displayName: 'Publish to PyPi'
-            condition: eq(variables['source_is_release_branch'], 'True')
-            env:
-              FLIT_PASSWORD: $(pypi_pw)
-              FLIT_USERNAME: $(pypi_user)
-
-          - script: |
-              set -e
-              cd $(System.DefaultWorkingDirectory)
               eval "$(conda shell.bash hook)"
               conda install anaconda-client
               anaconda login --username "${CONDA_USERNAME}" --password "${CONDA_PASSWORD}"
-              anaconda upload --user BCG_Gamma $(System.ArtifactsDirectory)/conda_default/conda/noarch/gamma-pytools-*.tar.bz2
+              anaconda upload --user BCG_Gamma --force $(System.ArtifactsDirectory)/conda_default/conda/noarch/gamma-pytools-*.tar.bz2
               anaconda logout
               echo "##vso[task.setvariable variable=conda_published]True"
             displayName: 'Publish to Anaconda'
 
+            condition: eq(variables['source_is_release_branch'], 'True')
+            env:
+              CONDA_PASSWORD: $(anaconda_pw)
+              CONDA_USERNAME: $(anaconda_user)
+
+          - script: |
+              set -e
+              cd $(System.DefaultWorkingDirectory)
+              pip install flit
+              flit publish
+              echo "##vso[task.setvariable variable=pypi_published]True"
+            displayName: 'Publish to PyPi'
             condition: >
               and(
               eq(variables['source_is_release_branch'], 'True'),
               succeededOrFailed()
               )
             env:
-              CONDA_PASSWORD: $(anaconda_pw)
-              CONDA_USERNAME: $(anaconda_user)
+              FLIT_PASSWORD: $(pypi_pw)
+              FLIT_USERNAME: $(pypi_user)
 
           - task: GitHubRelease@1
             condition: >

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,18 +364,13 @@ stages:
               importResults: false
               failBuildOnPolicyFail: false
 
-
-  # release on merges into release/*:
-  # - add release tag
-  # - create GitHub release with changelog
-  # - upload conda and pip packages as artifacts to GitHub
   - stage:
-    displayName: 'Release'
+    displayName: 'Check Release Version'
     dependsOn: conda_tox_build
 
     jobs:
       - job:
-        displayName: 'Release'
+        displayName: 'Check Release'
         condition: >
           or(
           eq(variables.source_is_release_branch, 'True'),
@@ -427,6 +422,35 @@ stages:
 
             displayName: "Check version consistency"
 
+
+  # release on merges into release/*:
+  # - add release tag
+  # - create GitHub release with changelog
+  # - upload conda and pip packages as artifacts to GitHub
+  - stage:
+    displayName: 'Release'
+    dependsOn: conda_tox_build
+    variables:
+    - group: artifact_publication
+
+    jobs:
+      - job:
+        displayName: 'Release'
+        condition: >
+          or(
+          eq(variables.source_is_release_branch, 'True'),
+          eq(variables.source_is_develop_branch, 'True')
+          )
+        
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.7.*'
+            displayName: 'use Python 3.7'
+
+          - checkout: self
+            path: pytools
+
           - task: Bash@3
             inputs:
               targetType: inline
@@ -453,8 +477,48 @@ stages:
             inputs:
               artifactName: conda_default
 
-          - task: GitHubRelease@1
+          - script: |
+              set -e
+              cd $(System.DefaultWorkingDirectory)
+              pip install flit
+              flit publish
+              echo "##vso[task.setvariable variable=pypi_published]True"
+            displayName: 'Publish to PyPi'
             condition: eq(variables['source_is_release_branch'], 'True')
+            env:
+              FLIT_PASSWORD: $(pypi_pw)
+              FLIT_USERNAME: $(pypi_user)
+
+          - script: |
+              set -e
+              cd $(System.DefaultWorkingDirectory)
+              eval "$(conda shell.bash hook)"
+              conda install anaconda-client
+              anaconda login --username "${CONDA_USERNAME}" --password "${CONDA_PASSWORD}"
+              anaconda upload --user BCG_Gamma $(System.ArtifactsDirectory)/conda_default/conda/noarch/gamma-pytools-*.tar.bz2
+              anaconda logout
+              echo "##vso[task.setvariable variable=conda_published]True"
+            displayName: 'Publish to Anaconda'
+            condition: 
+
+            condition: >
+              and(
+              eq(variables['source_is_release_branch'], 'True'),
+              succeededOrFailed()
+              )
+            env:
+              CONDA_PASSWORD: $(anaconda_pw)
+              CONDA_USERNAME: $(anaconda_user)
+
+          - task: GitHubRelease@1
+            condition: >
+              and(
+                eq(variables['source_is_release_branch'], 'True'),
+                or(
+                  eq(variables['conda_published'], 'True'),
+                  eq(variables['pypi_published'], 'True')
+                )
+              )
             inputs:
               gitHubConnection: github_release
               repositoryName: $(Build.Repository.Name)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -500,11 +500,7 @@ stages:
               flit publish
               echo "##vso[task.setvariable variable=pypi_published]True"
             displayName: 'Publish to PyPi'
-            condition: >
-              and(
-              eq(variables['source_is_release_branch'], 'True'),
-              succeededOrFailed()
-              )
+            condition: eq(variables['source_is_release_branch'], 'True')
             env:
               FLIT_PASSWORD: $(pypi_pw)
               FLIT_USERNAME: $(pypi_user)
@@ -513,6 +509,7 @@ stages:
             condition: >
               and(
                 eq(variables['source_is_release_branch'], 'True'),
+                succeededOrFailed(),
                 or(
                   eq(variables['conda_published'], 'True'),
                   eq(variables['pypi_published'], 'True')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -499,7 +499,6 @@ stages:
               anaconda logout
               echo "##vso[task.setvariable variable=conda_published]True"
             displayName: 'Publish to Anaconda'
-            condition: 
 
             condition: >
               and(


### PR DESCRIPTION
This PR prepares the pipeline for publishing:
- put the release version check in an own stage
- added two tasks to the release stage, one for `flit publish`, one for `anaconda upload`. Used the variables @konst-int-i created and passed to Bash – for `flit` it is fine already from ENV using the variable names it expects, for Anaconda, can be passed as command arguments to the login command
   - `flit publish` is self contained and does a source build + PyPi upload
   -  for the Anaconda upload, I am using the DevOps build artifacts which have the conda package tar.bz2 file 
- both publish tasks run on condition `source_is_release_branch` = True
- the second publish task, Conda, also runs with special condition `succeededOrFailed()` – for the case that a Conda upload failed, the PyPI upload worked out the first time, and will then fail the second time – pipeline can then skip over the PyPI upload and re-try the Conda one
- both upload steps return build variables: `conda_published` and `pypi_published` respectively if they succeeded
- the GitHub release stage will only run if either `conda_published` or `pypi_published` is True – the following docs stage depends on the GH release stage


Unfortunately we cannot easily test these steps without running somehow, so I hope for a rigorous review by **the fabolous facet team** 🤓 

Happy weekend. Looking forward to release soon!

