### PR TITLE
FIX: drawer style start_drawing and finalize_drawing

### DIFF
--- a/src/pytools/viz/_matplot.py
+++ b/src/pytools/viz/_matplot.py
@@ -143,8 +143,7 @@ class MatplotStyle(ColoredStyle[MatplotColorScheme], metaclass=ABCMeta):
         :param kwargs: additional drawer-specific arguments
         """
 
-        if kwargs:
-            raise ValueError(f"unknown keyword arguments: {kwargs}")
+        super().start_drawing(title=title, **kwargs)
 
         ax = self.ax
 
@@ -273,7 +272,7 @@ class ColorbarMatplotStyle(MatplotStyle, metaclass=ABCMeta):
         return self.colors.colormap(self.colormap_normalize(z))
 
     def finalize_drawing(
-        self, colorbar_label: Optional[str] = None, **kwargs: Any
+        self, *, colorbar_label: Optional[str] = None, **kwargs: Any
     ) -> None:
         """
         Add the color bar to the chart.

--- a/src/pytools/viz/_text.py
+++ b/src/pytools/viz/_text.py
@@ -72,8 +72,7 @@ class TextStyle(DrawingStyle, metaclass=ABCMeta):
         :param title: the title of the drawing
         :param kwargs: additional drawer-specific arguments
         """
-        if kwargs:
-            raise ValueError(f"unknown keyword arguments: {kwargs}")
+        super().start_drawing(title=title, **kwargs)
 
         print(f"{f' {title} ':*^{self.width}s}", file=self.out)
 

--- a/src/pytools/viz/dendrogram/_style.py
+++ b/src/pytools/viz/dendrogram/_style.py
@@ -3,7 +3,7 @@ Dendrogram styles.
 """
 
 import logging
-from typing import Optional, Sequence, TextIO
+from typing import Any, Optional, Sequence, TextIO
 
 from .. import TextStyle
 from ..color import text_contrast_color
@@ -127,6 +127,7 @@ class DendrogramHeatmapStyle(DendrogramMatplotStyle):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
+        **kwargs,
     ) -> None:
         """[see superclass]"""
         super().start_drawing(title=title)
@@ -301,9 +302,10 @@ class DendrogramReportStyle(DendrogramStyle, TextStyle):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
+        **kwargs,
     ) -> None:
         """[see superclass]"""
-        super().start_drawing(title=title)
+        super().start_drawing(title=title, **kwargs)
         self._char_matrix = CharacterMatrix(
             n_rows=self.max_height, n_columns=self.width
         )
@@ -314,10 +316,11 @@ class DendrogramReportStyle(DendrogramStyle, TextStyle):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         """[see superclass]"""
         try:
-            super().finalize_drawing()
+            super().finalize_drawing(**kwargs)
             for row in reversed(range(self._n_labels + 1)):
                 self.out.write(f"{self._char_matrix[row, :]}\n")
         finally:

--- a/src/pytools/viz/dendrogram/_style.py
+++ b/src/pytools/viz/dendrogram/_style.py
@@ -127,7 +127,7 @@ class DendrogramHeatmapStyle(DendrogramMatplotStyle):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """[see superclass]"""
         super().start_drawing(title=title)
@@ -302,7 +302,7 @@ class DendrogramReportStyle(DendrogramStyle, TextStyle):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """[see superclass]"""
         super().start_drawing(title=title, **kwargs)

--- a/src/pytools/viz/dendrogram/base/_style.py
+++ b/src/pytools/viz/dendrogram/base/_style.py
@@ -47,6 +47,7 @@ class DendrogramStyle(DrawingStyle, metaclass=ABCMeta):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
+        **kwargs,
     ) -> None:
         """
         Prepare a new dendrogram for drawing, using the given title.
@@ -56,23 +57,25 @@ class DendrogramStyle(DrawingStyle, metaclass=ABCMeta):
         :param distance_label: the label for the distance axis
         :param weight_label: the label for the weight scale
         """
-        super().start_drawing(title=title)
+        super().start_drawing(title=title, **kwargs)
 
-    @abstractmethod
     def finalize_drawing(
         self,
         *,
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
+        **kwargs,
     ) -> None:
         """
-        Finalize the dendrogram.
+        Finalize the dendrogram, adding labels to the axes.
 
         :param leaf_label: the label for the leaf axis
         :param distance_label: the label for the distance axis
         :param weight_label: the label for the weight scale
+        :param kwargs: additional drawer-specific arguments
         """
+        super().finalize_drawing(**kwargs)
 
     @abstractmethod
     def draw_leaf_names(
@@ -165,6 +168,7 @@ class DendrogramMatplotStyle(DendrogramStyle, ColorbarMatplotStyle, metaclass=AB
 
     def draw_leaf_names(self, *, names: Sequence[str]) -> None:
         """[see superclass]"""
+
         ax = self.ax
         y_axis = ax.yaxis
         y_axis.set_ticks(ticks=range(len(names)))
@@ -176,14 +180,10 @@ class DendrogramMatplotStyle(DendrogramStyle, ColorbarMatplotStyle, metaclass=AB
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
+        **kwargs,
     ) -> None:
-        """
-        Add labels to the axes of this drawing.
+        """[see superclass]"""
 
-        :param leaf_label: the label for the leaf axis
-        :param distance_label: the label for the distance axis
-        :param weight_label: the label for the color bar, indicating weights
-        """
         super().finalize_drawing(colorbar_label=weight_label)
 
         ax = self.ax

--- a/src/pytools/viz/dendrogram/base/_style.py
+++ b/src/pytools/viz/dendrogram/base/_style.py
@@ -4,7 +4,7 @@ Base classes for dendrogram styles.
 
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from matplotlib.axes import Axes
 from matplotlib.colors import LogNorm
@@ -47,7 +47,7 @@ class DendrogramStyle(DrawingStyle, metaclass=ABCMeta):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """
         Prepare a new dendrogram for drawing, using the given title.
@@ -56,6 +56,7 @@ class DendrogramStyle(DrawingStyle, metaclass=ABCMeta):
         :param leaf_label: the label for the leaf axis
         :param distance_label: the label for the distance axis
         :param weight_label: the label for the weight scale
+        :param kwargs: additional drawer-specific arguments
         """
         super().start_drawing(title=title, **kwargs)
 
@@ -65,7 +66,7 @@ class DendrogramStyle(DrawingStyle, metaclass=ABCMeta):
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """
         Finalize the dendrogram, adding labels to the axes.
@@ -180,7 +181,7 @@ class DendrogramMatplotStyle(DendrogramStyle, ColorbarMatplotStyle, metaclass=AB
         leaf_label: Optional[str] = None,
         distance_label: Optional[str] = None,
         weight_label: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """[see superclass]"""
 


### PR DESCRIPTION
This PR restores correct function signatures to methods overloading `DrawerStyle` methods `start_drawing` and `finalize_drawing`.

Both `DrawerStyle` are no longer abstract, and overloading methods must forward calls to the overloaded method.

Class `DrawerStyle` tracks whether the base methods are called, and an `AssertionError` will be raised if an overloaded method did not forward the call.