### PR TITLE
Release Pytools 1.0.2rc0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -481,7 +481,7 @@ stages:
               set -e
               cd $(System.DefaultWorkingDirectory)
               eval "$(conda shell.bash hook)"
-              conda install anaconda-client
+              conda install -y anaconda-client
               anaconda login --username "${CONDA_USERNAME}" --password "${CONDA_PASSWORD}"
               anaconda upload --user BCG_Gamma --force $(System.ArtifactsDirectory)/conda_default/conda/noarch/gamma-pytools-*.tar.bz2
               anaconda logout

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -478,7 +478,7 @@ stages:
               artifactName: conda_default
 
           - script: |
-              set -e
+              set -eux
               cd $(System.DefaultWorkingDirectory)
               eval "$(conda shell.bash hook)"
               conda install -y anaconda-client
@@ -494,7 +494,7 @@ stages:
               CONDA_USERNAME: $(anaconda_user)
 
           - script: |
-              set -e
+              set -eux
               cd $(System.DefaultWorkingDirectory)
               pip install flit
               flit publish
@@ -582,7 +582,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -e
+                set -eux
                 cd $(System.DefaultWorkingDirectory)
                 git checkout --track origin/github-pages
                 mkdir -p docs
@@ -597,7 +597,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -e
+                set -eux
                 eval "$(conda shell.bash hook)"
                 cd $(System.DefaultWorkingDirectory)
                 echo "Checking out $(branchName)"
@@ -615,7 +615,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -e
+                set -eux
                 eval "$(conda shell.bash hook)"
                 cp -r $(Build.ArtifactStagingDirectory)/old_docs/docs .
                 echo "Current docs contents:"
@@ -634,7 +634,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                set -e
+                set -eux
                 echo "Adjusting git credentials"
                 git config --global user.name "Azure Pipelines"
                 git config --global user.email "azuredevops@microsoft.com"


### PR DESCRIPTION
Second attempt (first one: #182)

Added a missing "-y" flag on Conda install and used "set -eux" for Bash release scripts. 