### PR TITLE
BUILD: bump pytools patch version to 1.0.3rc0

### DIFF
--- a/src/pytools/__init__.py
+++ b/src/pytools/__init__.py
@@ -1,4 +1,4 @@
 """
 A collection of Python extensions and tools used in BCG GAMMA's open-source libraries.
 """
-__version__ = "1.0.2"
+__version__ = "1.0.3rc0"


### PR DESCRIPTION
Bump pytools patch version to `1.0.3rc0`, as `1.0.2` was released. 