### PR TITLE
BUILD: allow to skip package version check based on ENV variable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,6 +142,7 @@ stages:
               conda env create -f environment.yml
               conda activate pytools-develop
               cd $(System.DefaultWorkingDirectory)
+              export RUN_PACKAGE_VERSION_TEST=pytools
               pytest \
                  --cov pytools \
                  --cov-config "tox.ini" \
@@ -229,6 +230,7 @@ stages:
             script: |
               if [ "$BUILD_SYSTEM" = "conda" ] ; then eval "$(conda shell.bash hook)" ; fi
               export PYTHONPATH=$(System.DefaultWorkingDirectory)/src
+              export RUN_PACKAGE_VERSION_TEST=pytools
               cd $(System.DefaultWorkingDirectory)
               ./make.py pytools $(BUILD_SYSTEM) $(PKG_DEPENDENCIES)
           displayName: "build & test conda/pip packages"
@@ -314,6 +316,7 @@ stages:
             script: |
               if [ "$BUILD_SYSTEM" = "conda" ] ; then eval "$(conda shell.bash hook)" ; fi
               export PYTHONPATH=$(System.DefaultWorkingDirectory)/src
+              export RUN_PACKAGE_VERSION_TEST=pytools
               cd $(System.DefaultWorkingDirectory)
               ./make.py pytools $(BUILD_SYSTEM) $(PKG_DEPENDENCIES)
           displayName: "build & test conda/pip packages"

--- a/make.py
+++ b/make.py
@@ -57,9 +57,6 @@ KNOWN_DEPENDENCY_TYPES = {DEFAULT_DEPS, MIN_DEPS, MAX_DEPS}
 CONDA_BUILD_PATH_SUFFIX = os.path.join("dist", "conda")
 TOX_BUILD_PATH_SUFFIX = os.path.join("dist", "tox")
 
-ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST = "SKIP_PYTOOLS_PACKAGE_VERSION_TEST"
-ENV_SKIP_SKLEARNDF_PACKAGE_VERSION_TEST = "SKIP_SKLEARNDF_PACKAGE_VERSION_TEST"
-
 
 class Builder(metaclass=ABCMeta):
     def __init__(self, project: str, dependency_type: str):
@@ -109,16 +106,6 @@ class Builder(metaclass=ABCMeta):
         ] = package_version
 
         self.package_version = package_version
-
-        # run the package version check (checks, if current sources have been released
-        # already on PyPi)
-        # only for the current project, not if a downstream package (e.g. facet)
-        # performs the build of an upstream package it needs (e.g. sklearndf, pytools)
-        if project != PROJ_PYTOOLS:
-            os.environ[ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST] = "1"
-
-        if project != PROJ_SKLEARNDF:
-            os.environ[ENV_SKIP_SKLEARNDF_PACKAGE_VERSION_TEST] = "1"
 
     @staticmethod
     def for_build_system(

--- a/make.py
+++ b/make.py
@@ -57,6 +57,9 @@ KNOWN_DEPENDENCY_TYPES = {DEFAULT_DEPS, MIN_DEPS, MAX_DEPS}
 CONDA_BUILD_PATH_SUFFIX = os.path.join("dist", "conda")
 TOX_BUILD_PATH_SUFFIX = os.path.join("dist", "tox")
 
+ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST = "SKIP_PYTOOLS_PACKAGE_VERSION_TEST"
+ENV_SKIP_SKLEARNDF_PACKAGE_VERSION_TEST = "SKIP_SKLEARNDF_PACKAGE_VERSION_TEST"
+
 
 class Builder(metaclass=ABCMeta):
     def __init__(self, project: str, dependency_type: str):
@@ -106,6 +109,16 @@ class Builder(metaclass=ABCMeta):
         ] = package_version
 
         self.package_version = package_version
+
+        # run the package version check (checks, if current sources have been released
+        # already on PyPi)
+        # only for the current project, not if a downstream package (e.g. facet)
+        # performs the build of an upstream package it needs (e.g. sklearndf, pytools)
+        if project != PROJ_PYTOOLS:
+            os.environ[ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST] = "1"
+
+        if project != PROJ_SKLEARNDF:
+            os.environ[ENV_SKIP_SKLEARNDF_PACKAGE_VERSION_TEST] = "1"
 
     @staticmethod
     def for_build_system(

--- a/test/test/pytools/test_package_version.py
+++ b/test/test/pytools/test_package_version.py
@@ -10,10 +10,12 @@ import pytools
 
 log = logging.getLogger(__name__)
 
-ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST = "SKIP_PYTOOLS_PACKAGE_VERSION_TEST"
+ENV_RUN_PACKAGE_VERSION_TEST = "RUN_PACKAGE_VERSION_TEST"
 
 
-@mark.skipif(condition=ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST in environ)
+@mark.skipif(
+    condition=environ.get(ENV_RUN_PACKAGE_VERSION_TEST, "") != pytools.__name__
+)
 def test_package_version() -> None:
     dev_version = pytools.__version__
 

--- a/test/test/pytools/test_package_version.py
+++ b/test/test/pytools/test_package_version.py
@@ -1,14 +1,20 @@
 import logging
 import re
+from os import environ
 from urllib import request
 from xml.etree import ElementTree
+
+from pytest import mark
 
 import pytools
 
 log = logging.getLogger(__name__)
 
+ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST = "SKIP_PYTOOLS_PACKAGE_VERSION_TEST"
 
-def test_package_version():
+
+@mark.skipif(condition=ENV_SKIP_PYTOOLS_PACKAGE_VERSION_TEST in environ)
+def test_package_version() -> None:
     dev_version = pytools.__version__
 
     log.info(f"Test package version – version set to: {dev_version}")

--- a/test/test/pytools/test_package_version.py
+++ b/test/test/pytools/test_package_version.py
@@ -14,7 +14,8 @@ ENV_RUN_PACKAGE_VERSION_TEST = "RUN_PACKAGE_VERSION_TEST"
 
 
 @mark.skipif(
-    condition=environ.get(ENV_RUN_PACKAGE_VERSION_TEST, "") != pytools.__name__
+    condition=environ.get(ENV_RUN_PACKAGE_VERSION_TEST, "") != pytools.__name__,
+    reason="Parent build is not primarily for pytools.",
 )
 def test_package_version() -> None:
     dev_version = pytools.__version__


### PR DESCRIPTION
This allows skipping of the pytest test case `test_package_version`, if the ENV variable `SKIP_PYTOOLS_PACKAGE_VERSION_TEST` is set.

This is useful, so that other "downstream" packages (sklearndf, facet, flow) can set this variable and skip this test (when they are building pytools), in their own build processes, which allows also to build them, in a constellation where a Pytools version has not been bumped to the next one yet (which would cause `test_package_version` for pytest to fail), but was relased already.