### PR TITLE
BUILD: add the bcg_gamma conda channel when building

### DIFF
--- a/make.py
+++ b/make.py
@@ -316,7 +316,7 @@ class CondaBuilder(Builder):
         print(f"Building: {self.project}. Build path: {build_path}")
         os.makedirs(build_path, exist_ok=True)
         build_cmd = (
-            f"conda-build -c conda-forge {' '.join(local_channels)} {recipe_path}"
+            f"conda-build -c conda-forge -c bcg_gamma {' '.join(local_channels)} {recipe_path}"
         )
         print(f"Build Command: {build_cmd}")
         subprocess.run(args=build_cmd, shell=True, check=True)

--- a/make.py
+++ b/make.py
@@ -316,7 +316,8 @@ class CondaBuilder(Builder):
         print(f"Building: {self.project}. Build path: {build_path}")
         os.makedirs(build_path, exist_ok=True)
         build_cmd = (
-            f"conda-build -c conda-forge -c bcg_gamma {' '.join(local_channels)} {recipe_path}"
+            f"conda-build -c conda-forge "
+            f"-c bcg_gamma {' '.join(local_channels)} {recipe_path}"
         )
         print(f"Build Command: {build_cmd}")
         subprocess.run(args=build_cmd, shell=True, check=True)


### PR DESCRIPTION
Background: Currently builds for `sklearndf` are failing as in their matrix test, they depend on an already released version of pytools, with a version smaller than what is currently on pytools/develop.

For PyPI, this is no problem, as our packages are on public PyPI – adding the bcg_gamma Conda channel, enables the same behaviour also for Conda builds.