### PR TITLE
DOCS: add pre-commit hook instructions to contribution guide

### DIFF
--- a/sphinx/source/contribution_guide.rst
+++ b/sphinx/source/contribution_guide.rst
@@ -16,10 +16,18 @@ required development dependencies in the ``pytools-develop`` environment.
 	conda env create -f environment.yml
 	conda activate pytools-develop
 
-This command will:
+Pre-commit hooks
+~~~~~~~~~~~~~~~~~~~~
+This project uses a number of pre-commit hooks such as black and flake8 to enforce
+uniform coding standards in all commits. Before committing code, please run
 
-- Install the conda environment
-- Install pre-commit hooks
+.. code-block:: sh
+
+    pre-commit install
+
+You can use ``pre-commit run`` to manually run the pre-commit hooks from the command
+line.
+
 
 Pytest
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
**This PR**: 
Adds instructions to install pre-commit hooks before contributing to the contribution guidelines. 

