### PR TITLE
BUILD: Enforce pre-release for minor and major releases

### DIFF
--- a/test/test/pytools/test_package_version.py
+++ b/test/test/pytools/test_package_version.py
@@ -48,7 +48,7 @@ def test_package_version() -> None:
         pre_releases = [
             version
             for version in releases
-            if re.match(r"^" + dev_version + r"rc\d+?$", version)
+            if re.match(r"^" + dev_version + r"rc\d+$", version)
         ]
 
         assert len(pre_releases), (

--- a/test/test/pytools/test_package_version.py
+++ b/test/test/pytools/test_package_version.py
@@ -35,28 +35,27 @@ def test_package_version() -> None:
     releases_nodes = tree.findall(path=".//channel//item//title")
     releases = [r.text for r in releases_nodes]
 
-    log.info(f"Found these releases on PyPi:{releases}")
+    log.info(f"Releases found on PyPi: {', '.join(releases)}")
 
     assert (
         dev_version not in releases
     ), f"Current package version {dev_version} already on PyPi"
 
-    is_major = dev_version.endswith(".0.0")
-    is_minor = dev_version.endswith(".0") and not is_major
+    is_minor_or_major_release = dev_version.endswith(".0")
 
-    if is_major or is_minor:
+    if is_minor_or_major_release:
         pre_releases = [
             version
             for version in releases
-            if re.match(r"^" + dev_version + r"rc\d+$", version)
+            if re.match(f"{dev_version}rc\\d+$", version)
         ]
 
         assert len(pre_releases), (
-            f"Release of major/minor version {dev_version} "
+            f"Release of major or minor version {dev_version} "
             f"requires at least one pre-release, e.g. {dev_version}rc0"
         )
 
         log.info(
             f"Pre-releases {pre_releases} exist(s) – "
-            f"release of major/minor version {dev_version} allowed."
+            f"release of major/minor version {dev_version} allowed"
         )

--- a/test/test/pytools/test_package_version.py
+++ b/test/test/pytools/test_package_version.py
@@ -40,3 +40,23 @@ def test_package_version() -> None:
     assert (
         dev_version not in releases
     ), f"Current package version {dev_version} already on PyPi"
+
+    is_major = dev_version.endswith(".0.0")
+    is_minor = dev_version.endswith(".0") and not is_major
+
+    if is_major or is_minor:
+        pre_releases = [
+            version
+            for version in releases
+            if re.match(r"^" + dev_version + r"rc\d+?$", version)
+        ]
+
+        assert len(pre_releases), (
+            f"Release of major/minor version {dev_version} "
+            f"requires at least one pre-release, e.g. {dev_version}rc0"
+        )
+
+        log.info(
+            f"Pre-releases {pre_releases} exist(s) – "
+            f"release of major/minor version {dev_version} allowed."
+        )

--- a/test/test/pytools/test_package_version.py
+++ b/test/test/pytools/test_package_version.py
@@ -50,7 +50,7 @@ def test_package_version() -> None:
             if re.match(f"{dev_version}rc\\d+$", version)
         ]
 
-        assert len(pre_releases), (
+        assert pre_releases, (
             f"Release of major or minor version {dev_version} "
             f"requires at least one pre-release, e.g. {dev_version}rc0"
         )


### PR DESCRIPTION
Extends the `test_package_version` test to enforce the existence of a pre-release (of same main version number) on PyPI, whenever `pytools.__version__` was set to a major or minor release version number.