### PR TITLE
API: AllTracker detection/prevention of exporting imported objects and global constants

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,13 +4,27 @@ Release Notes
 *pytools* 1.0
 -------------
 
+1.1.0
+~~~~~
+
+- API: AllTracker detects and prohibits exporting objects imported from other modules
+- API: AllTracker detects and prohibits exporting global constants (the preferred
+       approach is to define constants inside classes as this provides better context,
+       and will be properly documented via Sphinx)
+
+
+*pytools* 1.0
+-------------
+
 1.0.2
 ~~~~~
 
-This is a maintenance release focusing on enhancements to the CI/CD pipeline, along with minor fixes.
+This is a maintenance release focusing on enhancements to the CI/CD pipeline, along with
+minor fixes.
 
 - API: sort list of items returned by :meth:`.AllTracker.get_tracked`
-- API: add protected method to class :class:`.MatplotStyle` to apply color scheme to :class:`~matplotlib.axes.Axes` object
+- API: add protected method to class :class:`.MatplotStyle` to apply color scheme to
+       :class:`~matplotlib.axes.Axes` object
 - FIX: preserve correct instance for subclasses of singleton classes
 - FIX: add a few missing type hints
 - BUILD: add support for numpy 1.20

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,13 +4,27 @@ Release Notes
 *pytools* 1.0
 -------------
 
+1.1.0
+~~~~~
+
+- API: AllTracker detects and prohibits exporting objects imported from other modules
+- API: AllTracker detects and prohibits exporting global constants - the preferred
+       approach is to define constants inside classes as this provides better context,
+       and will be properly documented via Sphinx
+
+
+*pytools* 1.0
+-------------
+
 1.0.2
 ~~~~~
 
-This is a maintenance release focusing on enhancements to the CI/CD pipeline, along with minor fixes.
+This is a maintenance release focusing on enhancements to the CI/CD pipeline, along with
+minor fixes.
 
 - API: sort list of items returned by :meth:`.AllTracker.get_tracked`
-- API: add protected method to class :class:`.MatplotStyle` to apply color scheme to :class:`~matplotlib.axes.Axes` object
+- API: add protected method to class :class:`.MatplotStyle` to apply color scheme to
+       :class:`~matplotlib.axes.Axes` object
 - FIX: preserve correct instance for subclasses of singleton classes
 - FIX: add a few missing type hints
 - BUILD: add support for numpy 1.20

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -127,7 +127,7 @@ class AllTracker:
         globals_ = self._globals
 
         if set(globals_.get("__all__", [])) != set(all_expected):
-            raise RuntimeError(
+            raise AssertionError(
                 "missing or unexpected all declaration, "
                 f"expected:\n__all__ = {all_expected}"
             )

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -133,7 +133,11 @@ class AllTracker:
             obj = globals_[name]
 
             # set public module field
-            obj.__publicmodule__ = public_module
+            try:
+                obj.__publicmodule__ = public_module
+            except AttributeError:
+                # objects without a __dict__ will not permit setting the public module
+                pass
 
             if self.update_forward_references:
                 # update forward references in annotations

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -91,6 +91,11 @@ class AllTracker:
         self._globals = globals_
         self._imported = set(globals_.keys())
 
+        try:
+            self._module = module = globals_["__name__"]
+        except KeyError:
+            raise ValueError("arg globals_ does not define module name in __name__")
+
         if public_module:
             self.public_module = public_module
         else:

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -70,6 +70,21 @@ class AllTracker:
     used in the private module.
     """
 
+    #: if ``True``, automatically replace all forward
+    #: type references in function annotations with the referenced classes;
+    #: see :func:`.update_forward_references`
+    update_forward_references: bool
+
+    #: if ``True``, allow exporting public global constants in ``__all__``;
+    #: these typically have no ``__module__`` or ``__doc__`` attributes and will
+    #: not be properly rendered in generated documentation
+    allow_global_constants: bool
+
+    #: if ``True``, allow exporting definitions in ``__all__`` even if they have been
+    #: imported from another module
+    allow_imported_definitions: bool
+
+    # noinspection PyShadowingNames
     def __init__(
         self,
         globals_: Dict[str, Any],

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -661,12 +661,12 @@ def update_forward_references(
     :param globals_: a global namespace to search the referenced classes in
     """
 
-    def _update(obj: Any) -> None:
-        if isinstance(obj, type):
-            for member in vars(obj).values():
+    def _update(_obj: Any) -> None:
+        if isinstance(_obj, type):
+            for member in vars(_obj).values():
                 _update(member)
-        elif isinstance(obj, FunctionType):
-            annotations = obj.__annotations__
+        elif isinstance(_obj, FunctionType):
+            annotations = _obj.__annotations__
             if annotations:
                 for arg, cls in annotations.items():
                     if isinstance(cls, str):

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -68,6 +68,17 @@ class AllTracker:
 
     This ensures a clean namespace in the public package, uncluttered by any imports
     used in the private module.
+
+    The tracker also performs additional checks to validate the eligibility of
+    definitions for being exported:
+
+    - constant definitions should not be exported, as this will pose difficulties
+      with Sphinx documentation and - from a design perspective - provides less context
+      than defining constants inside classes
+    - definitions exported from other modules should not be re-exported by the importing
+      module
+
+    These validation checks can be overridden if required in special cases.
     """
 
     #: if ``True``, automatically replace all forward
@@ -137,7 +148,8 @@ class AllTracker:
         Validate that all eligible items that were defined since the creation of this
         tracker are listed in the ``__all__`` variable.
 
-        :raise RuntimeError: if ``__all__`` is not as expected
+        :raise AssertionError: if ``__all__`` is not as expected, or if one or more
+            definitions do not meet the required criteria to be exported (
         """
         all_expected = self.get_tracked()
 

--- a/src/pytools/viz/_matplot.py
+++ b/src/pytools/viz/_matplot.py
@@ -18,7 +18,7 @@ from matplotlib.tight_layout import get_renderer
 
 from ..api import AllTracker, inheritdoc
 from ._viz import ColoredStyle
-from .color import MatplotColorScheme, RgbaColor
+from .color import ColorScheme, MatplotColorScheme
 
 log = logging.getLogger(__name__)
 
@@ -261,7 +261,7 @@ class ColorbarMatplotStyle(MatplotStyle, metaclass=ABCMeta):
 
     __init__.__doc__ = MatplotStyle.__init__.__doc__ + __init__.__doc__
 
-    def color_for_value(self, z: float) -> RgbaColor:
+    def color_for_value(self, z: float) -> ColorScheme.RgbaColor:
         """
         Get the color associated with a given scalar, based on the color map and
         normalization defined for this style.

--- a/src/pytools/viz/color/_color.py
+++ b/src/pytools/viz/color/_color.py
@@ -20,8 +20,6 @@ log = logging.getLogger(__name__)
 #
 
 __all__ = [
-    "RgbColor",
-    "RgbaColor",
     "ColorScheme",
     "MatplotColorScheme",
     "FacetLightColorScheme",
@@ -35,55 +33,46 @@ __all__ = [
 
 __tracker = AllTracker(globals())
 
-#
-# Type definitions
-#
-
-#: RGB color type for use in color schemas and colored drawing styles.
-RgbColor = Tuple[float, float, float]
-
-#: RGB + Alpha color type for use in color schemas and colored drawing styles.
-RgbaColor = Tuple[float, float, float, float]
 
 #
 # Constants
 #
 
 #: Black.
-_RGB_BLACK: RgbColor = to_rgb("black")
+_RGB_BLACK: "ColorScheme.RgbColor" = to_rgb("black")
 
 #: White.
-_RGB_WHITE: RgbColor = to_rgb("white")
+_RGB_WHITE: "ColorScheme.RgbColor" = to_rgb("white")
 
 #: FACET light grey.
-_RGB_LIGHT_GREY: RgbColor = to_rgb("#c8c8c8")
+_RGB_LIGHT_GREY: "ColorScheme.RgbColor" = to_rgb("#c8c8c8")
 
 #: FACET grey.
-_RGB_GREY: RgbColor = to_rgb("#9a9a9a")
+_RGB_GREY: "ColorScheme.RgbColor" = to_rgb("#9a9a9a")
 
 #: FACET dark grey.
-_RGB_DARK_GREY: RgbColor = to_rgb("#3d3a40")
+_RGB_DARK_GREY: "ColorScheme.RgbColor" = to_rgb("#3d3a40")
 
 #: FACET dark blue.
-_RGB_DARK_BLUE: RgbColor = to_rgb("#295e7e")
+_RGB_DARK_BLUE: "ColorScheme.RgbColor" = to_rgb("#295e7e")
 
 #: FACET blue.
-_RGB_LIGHT_BLUE: RgbColor = to_rgb("#30c1d7")
+_RGB_LIGHT_BLUE: "ColorScheme.RgbColor" = to_rgb("#30c1d7")
 
 #: FACET green.
-_RGB_LIGHT_GREEN: RgbColor = to_rgb("#43fda2")
+_RGB_LIGHT_GREEN: "ColorScheme.RgbColor" = to_rgb("#43fda2")
 
 #: FACET status green.
-_RGB_GREEN: RgbColor = to_rgb("#3ead92")
+_RGB_GREEN: "ColorScheme.RgbColor" = to_rgb("#3ead92")
 
 #: FACET status amber.
-_RGB_AMBER: RgbColor = to_rgb("#a8b21c")
+_RGB_AMBER: "ColorScheme.RgbColor" = to_rgb("#a8b21c")
 
 #: FACET status red.
-_RGB_RED: RgbColor = to_rgb("#e61c57")
+_RGB_RED: "ColorScheme.RgbColor" = to_rgb("#e61c57")
 
 #: FACET dark red.
-_RGB_DARK_RED: RgbColor = to_rgb("#c41310")
+_RGB_DARK_RED: "ColorScheme.RgbColor" = to_rgb("#c41310")
 
 #: Standard colormap for FACET.
 _COLORMAP_FACET = LinearSegmentedColormap.from_list(
@@ -108,6 +97,12 @@ class ColorScheme(HasExpressionRepr):
     A color scheme mapping semantic color designations to RGB colors,
     allowing code to refer to colors by usage rather than specific RGB values.
     """
+
+    #: RGB color type for use in color schemas and colored drawing styles.
+    RgbColor = Tuple[float, float, float]
+
+    #: RGB + Alpha color type for use in color schemas and colored drawing styles.
+    RgbaColor = Tuple[float, float, float, float]
 
     def __init__(
         self, foreground: RgbColor, background: RgbColor, **colors: RgbColor
@@ -286,10 +281,10 @@ class MatplotColorScheme(ColorScheme):
 
     def __init__(
         self,
-        foreground: Union[RgbColor, str],
-        background: Union[RgbColor, str],
+        foreground: Union[ColorScheme.RgbColor, str],
+        background: Union[ColorScheme.RgbColor, str],
         colormap: Union[Colormap, str],
-        **colors: Union[RgbColor, str],
+        **colors: Union[ColorScheme.RgbColor, str],
     ) -> None:
         """
         :param colormap: the colormap for this style
@@ -327,7 +322,9 @@ class MatplotColorScheme(ColorScheme):
 
 @inheritdoc(match="[see superclass]")
 class _FacetColorScheme(MatplotColorScheme):
-    def __init__(self, foreground: RgbColor, background: RgbColor) -> None:
+    def __init__(
+        self, foreground: ColorScheme.RgbColor, background: ColorScheme.RgbColor
+    ) -> None:
         super().__init__(
             foreground=foreground,
             background=background,
@@ -378,8 +375,8 @@ class FacetDarkColorScheme(
 
 
 def text_contrast_color(
-    bg_color: Union[RgbColor, RgbaColor]
-) -> Union[RgbColor, RgbaColor]:
+    bg_color: Union[ColorScheme.RgbColor, ColorScheme.RgbaColor]
+) -> Union[ColorScheme.RgbColor, ColorScheme.RgbaColor]:
     """
     Get a text color that maximises contrast with the given background color.
 


### PR DESCRIPTION
With this PR, the ``AllTracker`` will detect and prohibit

- exporting objects imported from other modules
- exporting global constants (the preferred approach is to define constants inside classes as this provides better context, and will be properly documented via Sphinx)