### PR TITLE
FIX: do not attempt to replace 3rd party documentation for attributes

### DIFF
--- a/src/pytools/sphinx/_sphinx.py
+++ b/src/pytools/sphinx/_sphinx.py
@@ -784,6 +784,11 @@ class Replace3rdPartyDoc(AutodocProcessDocstring):
     ) -> None:
         """[see superclass]"""
 
+        if what == "attribute":
+            # we cannot determine docstrings for attributes, as the object represents
+            # the value of the attribute, and not the attribute itself
+            return
+
         try:
             obj_module = obj.__module__
         except AttributeError:


### PR DESCRIPTION
We cannot determine whether an attribute was introduced by a 3rd party module, so this PR prevents this test for attributes and prevents subsequent failures.