### PR TITLE
BUILD: add copy of old docs-versions folder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -626,6 +626,8 @@ stages:
                 cp -r $(Build.ArtifactStagingDirectory)/old_docs/docs .
                 echo "Current docs contents:"
                 tree docs
+                mkdir -p sphinx/build/
+                cp -R docs/docs-version sphinx/build/
                 conda activate pytools-develop
                 python sphinx/make.py prepare_docs_deployment
                 echo "Current docs contents:"


### PR DESCRIPTION
This corrects the scenario that older version.js files are not patched, by copying pre-existing docs-version folders where the makefile for docs expects them.

Similar change as:
https://github.com/BCG-Gamma/sklearndf/pull/161
https://github.com/BCG-Gamma/facet/pull/268