### PR TITLE
API: use current axes as default in MatplotStyle

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,12 @@ Release Notes
 *pytools* 1.1
 -------------
 
+1.1.1
+~~~~~
+
+- API: :class:`.MatplotStyle` now uses PyPlot's current axes by default, instead of
+  creating a new figure and axis
+
 1.1.0
 ~~~~~
 

--- a/src/pytools/viz/_matplot.py
+++ b/src/pytools/viz/_matplot.py
@@ -74,8 +74,7 @@ class MatplotStyle(ColoredStyle[MatplotColorScheme], metaclass=ABCMeta):
         """
         ax = self._ax
         if ax is None:
-            _, ax = plt.subplots()
-            self._ax = ax
+            self._ax = ax = plt.gca()
         return ax
 
     @property


### PR DESCRIPTION
This PR makes a small but significant change: It allows `pytools.viz` to create multiple subplots in the same figure, by not forcing the creation of a new figure on every call to the `draw()` method.