### PR TITLE
FIX: version syntax adaptation with mixed = and >=

### DIFF
--- a/make.py
+++ b/make.py
@@ -335,7 +335,7 @@ class ToxBuilder(Builder):
 
     def adapt_version_syntax(self, version: str) -> str:
         # PIP expects == instead of =
-        return re.sub(r"(?<![<>])=(?![<>])", "==", version)
+        return re.sub(r"(?<![<=>])=(?![<=>])", "==", version)
 
     def clean(self) -> None:
         # nothing to do – .tar.gz of same version will simply be replaced and

--- a/make.py
+++ b/make.py
@@ -7,6 +7,7 @@ import importlib
 import importlib.util
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -333,11 +334,8 @@ class ToxBuilder(Builder):
         return TOX_BUILD_PATH_SUFFIX
 
     def adapt_version_syntax(self, version: str) -> str:
-        if ">" in version or "<" in version:
-            return version
-        else:
-            # PIP expects == instead of =
-            return version.replace("=", "==")
+        # PIP expects == instead of =
+        return re.sub(r"(?<![<>])=(?![<>])", "==", version)
 
     def clean(self) -> None:
         # nothing to do – .tar.gz of same version will simply be replaced and


### PR DESCRIPTION
This PR enables version syntax adaptation for conda in cases where a version string contains both a "=" and a ">="/">"/"<="/"<" clause