### PR TITLE
API: support inheriting class docstrings from superclasses in @inheritdoc; add @subsdoc decorator to replace text in docstrings

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,9 @@ Release Notes
 ~~~~~
 
 - FIX: do not substitute ~= by ~== when adapting version syntax for tox
+- API: support inheriting class docstrings from superclasses using the
+  :func:`.inheritdoc` decorator
+- API: new :func:`.subsdoc` decorator to replace text in docstrings
 
 
 1.0.3

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,15 @@ Release Notes
 *pytools* 1.1
 -------------
 
+1.1.2
+~~~~~
+
+- Catch up with fixes and pipeline updates introduced by pytools 1.0.3 and 1.0.4
+- API: support inheriting class docstrings from superclasses using the
+  :func:`.inheritdoc` decorator
+- API: new :func:`.subsdoc` decorator to replace text in docstrings
+
+
 1.1.1
 ~~~~~
 
@@ -29,9 +38,6 @@ Release Notes
 ~~~~~
 
 - FIX: do not substitute ~= by ~== when adapting version syntax for tox
-- API: support inheriting class docstrings from superclasses using the
-  :func:`.inheritdoc` decorator
-- API: new :func:`.subsdoc` decorator to replace text in docstrings
 
 
 1.0.3

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -37,6 +37,7 @@ __all__ = [
     "inheritdoc",
     "is_list_like",
     "public_module_prefix",
+    "subsdoc",
     "to_list",
     "to_set",
     "to_tuple",
@@ -698,6 +699,33 @@ def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
         return _cls
 
     return _inheritdoc_inner
+
+
+def subsdoc(*, pattern: str, replacement: str) -> Callable[[T], T]:
+    """
+    Decorator that matches a given pattern in the decorated object's docstring, and
+    substitutes it with the given replacement string (see :func:`re.sub`)
+
+    :param pattern: a regular expression for the pattern to match
+    :param replacement: the replacement for substrings matching the pattern
+    :return: the parameterized decorator
+    """
+
+    def _decorate(_obj: T) -> T:
+        if not isinstance(_obj.__doc__, str):
+            raise ValueError(f"docstring of {_obj!r} is not a string: {_obj.__doc__!r}")
+        _obj.__doc__, n = re.subn(pattern, replacement, _obj.__doc__)
+        if not n:
+            raise ValueError(
+                f"subsdoc: pattern {pattern!r} not found in docstring {_obj.__doc__!r}"
+            )
+        return _obj
+
+    if not (isinstance(pattern, str)):
+        raise ValueError("arg pattern must be a string")
+    if not (isinstance(replacement, str)):
+        raise ValueError("arg replacement must be a string")
+    return _decorate
 
 
 def update_forward_references(

--- a/test/test/pytools/test_api.py
+++ b/test/test/pytools/test_api.py
@@ -8,7 +8,7 @@ import pytest
 
 print(sys.path)
 
-from pytools.api import deprecated
+from pytools.api import deprecated, subsdoc
 
 
 def test_deprecated() -> None:
@@ -31,3 +31,12 @@ def test_deprecated() -> None:
         match="Call to deprecated function test_deprecated.<locals>._g: test message",
     ):
         _g()
+
+
+def test_subsdoc() -> None:
+    class _A:
+        @subsdoc(pattern=r"a(\d)c", replacement=r"A\1C")
+        def _f(self) -> None:
+            """a5c aac a3c"""
+
+    assert _A._f.__doc__ == "A5C aac A3C"


### PR DESCRIPTION
- `@inheritdoc` now also supports inheriting class docstrings from superclasses
- the new `@subsdoc` decorator can be used to replace text in inherited docstrings; it raises an exception when no match was found ("fail fast" approach). It is especially useful in conjunction with `@inheritdoc` to change text in inherited docstrings