### PR TITLE
FIX: return eq_=False when one infix expression is a prefix of the other

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,10 +7,7 @@ Release Notes
 1.0.6
 ~~~~~
 
-- FIX: comparing two :class:`.InfixExpression` objects using method
-  :meth:`~.Expression.eq_` would erroneously yield ``True`` if both expressions
-  had the same operator but a different number of operands, and the operands of the
-  shorter expression were equal to the operands at the start of the longer expression
+- FIX: back-port 1.1 bugfix for :meth:`~.Expression.eq_`
 
 
 1.0.5

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,15 @@ Release Notes
 *pytools* 1.0
 -------------
 
+1.0.6
+~~~~~
+
+- FIX: comparing two :class:`.InfixExpression` objects using method
+  :meth:`~.Expression.eq_` would erroneously yield ``True`` if both expressions
+  had the same operator but a different number of operands, and the operands of the
+  shorter expression were equal to the operands at the start of the longer expression
+
+
 1.0.5
 ~~~~~
 

--- a/src/pytools/expression/base/_base.py
+++ b/src/pytools/expression/base/_base.py
@@ -446,8 +446,12 @@ class InfixExpression(Expression, metaclass=ABCMeta):
         )
 
     def _eq_same_type(self, other: "InfixExpression") -> bool:
-        return self.infix_ == other.infix_ and all(
-            a.eq_(b) for a, b in zip(self.subexpressions_, other.subexpressions_)
+        return (
+            self.infix_ == other.infix_
+            and len(self.subexpressions_) == len(other.subexpressions_)
+            and all(
+                a.eq_(b) for a, b in zip(self.subexpressions_, other.subexpressions_)
+            )
         )
 
 


### PR DESCRIPTION
comparing two infix expressions with the same operator would erroneously yield `True` if one expression is shorter than the other, and the sequence of operands in the longer expression starts with all operands from the shorter expression