### PR TITLE
BUILD: prepare package requirements to support scikit-learn 0.24 in sklearndf

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -13,6 +13,7 @@ Release Notes
   :func:`.to_collection`, and :func:`.validate_element_types` now accept multiple
   alternative types to validate elements against, in line with how :func:`isinstance`
   tests for multiple types
+- BUILD: add support for matplotlib >= 3.4, scipy >= 1.6, and typing-inspect == 0.7
 
 
 *pytools* 1.1

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - numpy ~= 1.16
   - pandas ~= 1.2
   - python ~= 3.8
-  - scipy ~= 1.5
-  - typing_inspect ~= 0.6
+  - scipy ~= 1.6
+  - typing_inspect ~= 0.7
   # build/test
   - black = 20.8b1
   - conda-build ~= 3.20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
     "numpy          >=1.16,<1.21a",
     "pandas         >=0.24,<2a",
     "scipy          ~=1.2",
-    "typing_inspect >=0.4,<0.7a",
+    "typing_inspect >=0.4,<0.8a",
 ]
 
 requires-python = "~=3.6"
@@ -84,7 +84,7 @@ packaging      = "=20.*"
 pandas         = "~=1.2"
 python         = "~=3.8"
 scipy          = "~=1.6"
-typing_inspect = "=0.6.*"
+typing_inspect = "=0.7.*"
 
 [tool.black]
 # quiet = "True"


### PR DESCRIPTION
update package requirements to:
- `scipy` 1.6
- `typing_inspect` 0.7