### PR TITLE
FIX: unpack first operand aliases when comparing binary expressions

### DIFF
--- a/src/pytools/expression/base/_base.py
+++ b/src/pytools/expression/base/_base.py
@@ -445,14 +445,5 @@ class InfixExpression(Expression, metaclass=ABCMeta):
             )
         )
 
-    def _eq_same_type(self, other: "InfixExpression") -> bool:
-        return (
-            self.infix_ == other.infix_
-            and len(self.subexpressions_) == len(other.subexpressions_)
-            and all(
-                a.eq_(b) for a, b in zip(self.subexpressions_, other.subexpressions_)
-            )
-        )
-
 
 __tracker.validate()

--- a/src/pytools/expression/composite/_composite.py
+++ b/src/pytools/expression/composite/_composite.py
@@ -7,7 +7,7 @@ from abc import ABCMeta
 from typing import Any, Tuple, TypeVar, Union, cast
 
 from ...api import AllTracker, inheritdoc
-from .. import Expression, make_expression
+from .. import Expression, ExpressionAlias, make_expression
 from ..atomic import Epsilon, Id
 from ..base import (
     BracketPair,
@@ -184,11 +184,13 @@ class BinaryOperation(InfixExpression, Operation):
 
         first_operand = operands[0]
 
-        if isinstance(first_operand, BinaryOperation):
-            if first_operand.operator_ == operator:
-                # if first operand has the same operator, we flatten the operand
-                # noinspection PyUnresolvedReferences
-                operands = (*first_operand.operands_, *operands[1:])
+        if (
+            isinstance(first_operand, BinaryOperation)
+            and first_operand.operator_ == operator
+        ):
+            # if first operand has the same operator, we flatten the operand
+            # noinspection PyUnresolvedReferences
+            operands = (*first_operand.operands_, *operands[1:])
 
         self._operator = operator
         self._operands = operands
@@ -212,6 +214,31 @@ class BinaryOperation(InfixExpression, Operation):
     def precedence_(self) -> int:
         """[see superclass]"""
         return self.infix_.precedence
+
+    def _flattened_operands(self) -> Tuple[Expression, ...]:
+        operands = self.operands_
+        first_operand = operands[0]
+
+        while isinstance(first_operand, ExpressionAlias):
+            first_operand = first_operand.expression_
+
+            if (
+                isinstance(first_operand, BinaryOperation)
+                and first_operand.operator_ == self.operator_
+            ):
+                return (*first_operand._flattened_operands(), *operands[1:])
+
+        return operands
+
+    def _eq_same_type(self, other: "BinaryOperation") -> bool:
+        if self.operator_ == other.operator_:
+            self_operands_ = self._flattened_operands()
+            other_operands_ = other._flattened_operands()
+            return len(self_operands_) == len(other_operands_) and all(
+                a.eq_(b) for a, b in zip(self_operands_, other_operands_)
+            )
+        else:
+            return False
 
 
 #

--- a/src/pytools/expression/composite/_composite.py
+++ b/src/pytools/expression/composite/_composite.py
@@ -16,9 +16,8 @@ from ..base import (
     Invocation,
     Operation,
     SimplePrefixExpression,
-    SingletonExpression,
 )
-from ..operator import BinaryOperator, Operator, UnaryOperator
+from ..operator import BinaryOperator, UnaryOperator
 from .base import DictEntry, KeywordArgument, LambdaDefinition
 
 log = logging.getLogger(__name__)
@@ -29,7 +28,6 @@ log = logging.getLogger(__name__)
 #
 
 __all__ = [
-    "BracketedExpression",
     "ListLiteral",
     "TupleLiteral",
     "SetLiteral",
@@ -65,50 +63,6 @@ __tracker = AllTracker(globals())
 #
 # Bracketed expressions
 #
-
-
-@inheritdoc(match="[see superclass]")
-class BracketedExpression(SingletonExpression, metaclass=ABCMeta):
-    """
-    An expression surrounded by brackets.
-    """
-
-    def __init__(self, brackets: BracketPair, subexpression: Any) -> None:
-        """
-        :param brackets: the brackets enclosing this expression's subexpressions
-        :param subexpression: the subexpression enclosed by brackets
-        """
-        super().__init__()
-        self._brackets = brackets
-        self._subexpression = make_expression(subexpression)
-
-    @property
-    def brackets_(self) -> BracketPair:
-        """
-        The brackets enclosing this expression's subexpressions.
-        """
-        return self._brackets
-
-    @property
-    def subexpression_(self) -> Expression:
-        """
-        The subexpression enclosed by the brackets.
-        """
-        return self._subexpression
-
-    @property
-    def precedence_(self) -> int:
-        """[see superclass]"""
-        return Operator.MAX_PRECEDENCE
-
-    def hash_(self) -> int:
-        """[see superclass]"""
-        return hash((type(self), self.brackets_, self.subexpression_.hash_()))
-
-    def _eq_same_type(self, other: "BracketedExpression") -> bool:
-        return self.brackets_ == other.brackets_ and self.subexpression_.eq_(
-            other.subexpression_
-        )
 
 
 class ListLiteral(CollectionLiteral):


### PR DESCRIPTION
- remove duplicated definition of class BracketedExpression
- unpack first operand aliases when comparing binary expressions