### PR TITLE
FIX: always use leaf weights for labels in dendrogram report style

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,12 +4,19 @@ Release Notes
 *pytools* 1.1
 -------------
 
+1.1.6
+~~~~~
+
+- FIX: ensure correct weight labels when rendering dendograms as plain text using the
+  :class:`.DendrogramReportStyle`
+
+
 1.1.5
 ~~~~~
 
-- FIX: fixed a rare case where :meth:`~.Expression.eq_` returned `False` for two
-  equivalent expressions if one of them included an :class:`~.ExpressionAlias`
-- FIX: accept any type of numerical values as leaf weights of :class:`~.LinkageTree`
+- FIX: fixed a rare case where :meth:`.Expression.eq_` returned `False` for two
+  equivalent expressions if one of them included an :class:`.ExpressionAlias`
+- FIX: accept any type of numerical values as leaf weights of :class:`.LinkageTree`
 
 
 1.1.4
@@ -22,7 +29,7 @@ Release Notes
 ~~~~~
 
 - FIX: comparing two :class:`.InfixExpression` objects using method
-  :meth:`~.Expression.eq_` would erroneously yield ``True`` if both expressions
+  :meth:`.Expression.eq_` would erroneously yield ``True`` if both expressions
   had the same operator but a different number of operands, and the operands of the
   shorter expression were equal to the operands at the start of the longer expression
 
@@ -62,7 +69,7 @@ Release Notes
 1.0.6
 ~~~~~
 
-- FIX: back-port 1.1 bugfix for :meth:`~.Expression.eq_`
+- FIX: back-port 1.1 bugfix for :meth:`.Expression.eq_`
 
 
 1.0.5

--- a/src/pytools/viz/dendrogram/_style.py
+++ b/src/pytools/viz/dendrogram/_style.py
@@ -19,8 +19,8 @@ log = logging.getLogger(__name__)
 #
 
 __all__ = [
-    "DendrogramLineStyle",
     "DendrogramHeatmapStyle",
+    "DendrogramLineStyle",
     "DendrogramReportStyle",
 ]
 
@@ -251,8 +251,11 @@ class DendrogramReportStyle(DendrogramStyle, TextStyle):
         # between two text lines (using an underscore symbol)
         is_in_between_line = round(leaf * 2) & 1
 
+        # get the character matrix
+        matrix = self._char_matrix
+
         # draw the link leg in the character matrix
-        self._char_matrix[
+        matrix[
             line_y + is_in_between_line,
             self._x_pos(bottom, tree_height) : self._x_pos(top, tree_height),
         ] = (
@@ -260,8 +263,8 @@ class DendrogramReportStyle(DendrogramStyle, TextStyle):
         )
 
         # if we're in a leaf, we can draw the weight next to he label
-        if bottom == 0:
-            self._char_matrix[
+        if bottom == 0.0 and matrix[line_y, self.label_width - 2] == " ":
+            matrix[
                 line_y, self.__weight_column : self.label_width
             ] = f"{weight * 100:3.0f}%"
 

--- a/test/test/pytools/viz/dendrogram/test_dendrogram.py
+++ b/test/test/pytools/viz/dendrogram/test_dendrogram.py
@@ -38,7 +38,7 @@ def linkage_tree(linkage_matrix: np.ndarray) -> LinkageTree:
 
 
 def test_dendrogram_drawer_text(linkage_matrix: np.ndarray) -> None:
-    checksum_dendrogram_report = "2d94fe5966d1fb77b4216c16e9845da6"
+    checksum_dendrogram_report = "32427095857f0589f68210ad4b2e8210"
     leaf_names = list("ABCDEFGH")
     leaf_weights = [(w + 1) / 36 for w in range(8)]
 


### PR DESCRIPTION
This PR fixes a bug causing incorrect weight labels when rendering dendograms as text using the `DendrogramReportStyle`.