### PR TITLE
API: ResolveGenericClassParameters: resolve type vars for self or cls

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,7 +11,8 @@ This release enhances support for generating Sphinx documentation, and catches u
 *pytools* 1.1.6.
 
 - API: add sphinx processor :class:`.ResolveGenericClassParameters`
-  to resolve generic type parameters in subclasses
+  to substitute generic type parameters introduced by base classes or via the
+  ``self`` and ``cls`` special method arguments
 - API: add sphinx processor :class:`.AutodocProcessBases` to handle
   `autodoc-process-bases` events (introduced in Sphinx 4.1)
 

--- a/src/pytools/sphinx/_sphinx_py37.py
+++ b/src/pytools/sphinx/_sphinx_py37.py
@@ -147,6 +147,79 @@ class ResolveGenericClassParameters(AutodocBeforeProcessSignature):
         self.original_signatures = {}
         self._current_class_bindings = None
 
+    def _resolve_signature(
+        self, bindings: _TypeVarBindings, func: FunctionType
+    ) -> None:
+        defining_class = self._get_defining_class(func)
+
+        if defining_class is None:
+            # no or unknown defining class: nothing to resolve in the signature
+            return
+
+        log.debug(f"function {func} was defined in {defining_class}")
+
+        method_type = self._get_method_type(defining_class, func)
+
+        # get the actual signature object that we will modify
+        signature = func.__annotations__
+        if not signature:
+            return
+
+        # get the original signature and convert it to a list of (name, type) tuples
+        signature_original_items = list(self._get_original_signature(func).items())
+
+        arg_0_type_var: Optional[TypeVar] = None
+        arg_0_substitute: Optional[Type] = None
+
+        if not signature_original_items:
+            arg_0_type_var = None
+
+        elif method_type is METHOD_TYPE_DYNAMIC:
+            # special case: we substitute type vars bound to the class
+            # when assigned to the 'self' or 'cls' parameters of methods
+            _, arg_0_type = signature_original_items[0]
+            if typing_inspect.is_typevar(arg_0_type):
+                arg_0_type_var = arg_0_type
+                arg_0_substitute = bindings.current_class
+
+        elif method_type is METHOD_TYPE_CLASS:
+            # special case: we substitute type vars bound to the class
+            # when assigned to the 'self' or 'cls' parameters of methods
+            _, arg_0_type = signature_original_items[0]
+            if (
+                typing_inspect.is_generic_type(arg_0_type)
+                and typing_inspect.get_origin(arg_0_type) is type
+            ):
+                arg_0_type_args = typing_inspect.get_args(arg_0_type)
+                if len(arg_0_type_args) == 1 and typing_inspect.is_typevar(
+                    arg_0_type_args[0]
+                ):
+                    arg_0_type_var = arg_0_type_args[0]
+                    arg_0_substitute = bindings.current_class
+
+        def _substitute(_tp: Union[Type, TypeVar]) -> type:
+            # recursively substitute type vars with their resolutions
+            if isinstance(_tp, TypeVar):
+                if _tp == arg_0_type_var:
+                    # special case: substitute a type variable introduced by the
+                    # initial self/cls argument of a dynamic or class method
+                    return arg_0_substitute
+                else:
+                    # resolve type variables defined by Generic[] in the
+                    # class hierarchy
+                    return bindings.resolve_parameter(defining_class, _tp)
+            else:
+                # dynamically resolve type variables inside nested type expressions
+                args = typing_inspect.get_args(_tp)
+                if args:
+                    # noinspection PyUnresolvedReferences
+                    return _tp.copy_with(tuple(map(_substitute, args)))
+                else:
+                    return _tp
+
+        for name, tp in signature_original_items:
+            signature[name] = _substitute(tp)
+
     @staticmethod
     def _get_defining_class(method: FunctionType) -> Optional[type]:
         # get the class that defined the callable
@@ -168,17 +241,26 @@ class ResolveGenericClassParameters(AutodocBeforeProcessSignature):
             )
             return None
 
-    def _resolve_signature(
-        self, bindings: _TypeVarBindings, func: FunctionType
-    ) -> None:
-        defining_class = self._get_defining_class(func)
+    @staticmethod
+    def _get_method_type(defining_class: type, func: FunctionType) -> int:
+        # do we have a static or class method?
+        try:
+            raw_func = getattr_static(defining_class, func.__name__)
+            if isinstance(raw_func, staticmethod):
+                return METHOD_TYPE_STATIC
+            elif isinstance(raw_func, classmethod):
+                return METHOD_TYPE_CLASS
+        except AttributeError:
+            # this should not happen, but we try to handle this gracefully
+            log.warning(
+                f"failed to look up method {func.__name__!r} "
+                f"in class {defining_class.__name__}"
+            )
+        return METHOD_TYPE_DYNAMIC
 
-        if defining_class is None:
-            # no or unknown defining class: nothing to resolve in the signature
-            return
-
-        log.debug(f"function {func} was defined in {defining_class}")
-
+    def _get_original_signature(
+        self, func: FunctionType
+    ) -> Dict[str, Union[type, TypeVar]]:
         # get the original signature as defined in the code
         signature_original: Dict[str, Union[type, TypeVar]]
         try:
@@ -186,83 +268,7 @@ class ResolveGenericClassParameters(AutodocBeforeProcessSignature):
         except KeyError:
             signature_original = get_type_hints(func)
             self.original_signatures[func] = signature_original
-
-        # do we have a static or class method?
-        method_type = METHOD_TYPE_DYNAMIC
-        try:
-            raw_func = getattr_static(defining_class, func.__name__)
-            if isinstance(raw_func, staticmethod):
-                method_type = METHOD_TYPE_STATIC
-            elif isinstance(raw_func, classmethod):
-                method_type = METHOD_TYPE_CLASS
-        except AttributeError:
-            # this should not happen, but we try to handle this gracefully
-            log.warning(
-                f"failed to look up method {func.__name__!r} "
-                f"in class {defining_class.__name__}"
-            )
-
-        # get the actual signature object that we will modify
-        signature = func.__annotations__
-        if signature:
-
-            # get the original signature and convert it to a list of (name, type) tuples
-            signature_original_items = list(signature_original.items())
-
-            if not signature_original_items:
-                arg_0_type_var: Optional[Type] = None
-                arg_0_substitute: Optional[Type] = None
-
-            elif method_type is METHOD_TYPE_DYNAMIC:
-                # special case: we substitute type vars bound to the class
-                # when assigned to the 'self' or 'cls' parameters of methods
-                _, arg_0_type_var = signature_original_items[0]
-                if typing_inspect.is_typevar(arg_0_type_var):
-                    arg_0_substitute = bindings.current_class
-                else:
-                    arg_0_type_var = None
-
-            elif method_type is METHOD_TYPE_CLASS:
-                # special case: we substitute type vars bound to the class
-                # when assigned to the 'self' or 'cls' parameters of methods
-                _, arg_0_type = signature_original_items[0]
-                if (
-                    typing_inspect.is_generic_type(arg_0_type)
-                    and typing_inspect.get_origin(arg_0_type) is type
-                ):
-                    arg_0_type_args = typing_inspect.get_args(arg_0_type)
-                    if len(arg_0_type_args) == 1 and typing_inspect.is_typevar(
-                        arg_0_type_args[0]
-                    ):
-                        arg_0_type_var = arg_0_type_args[0]
-                        arg_0_substitute = bindings.current_class
-                    else:
-                        arg_0_type_var = None
-                else:
-                    arg_0_type_var = None
-
-            def _substitute(_tp: Union[Type, TypeVar]) -> type:
-                # recursively substitute type vars with their resolutions
-                if isinstance(_tp, TypeVar):
-                    if _tp == arg_0_type_var:
-                        # special case: substitute a type variable introduced by the
-                        # initial self/cls argument of a dynamic or class method
-                        return arg_0_substitute
-                    else:
-                        # resolve type variables defined by Generic[] in the
-                        # class hierarchy
-                        return bindings.resolve_parameter(defining_class, _tp)
-                else:
-                    # dynamically resolve type variables inside nested type expressions
-                    args = typing_inspect.get_args(_tp)
-                    if args:
-                        # noinspection PyUnresolvedReferences
-                        return _tp.copy_with(tuple(map(_substitute, args)))
-                    else:
-                        return _tp
-
-            for name, tp in signature_original_items:
-                signature[name] = _substitute(tp)
+        return signature_original
 
     def process(self, app: Sphinx, obj: Any, bound_method: bool) -> None:
         """[see superclass]"""

--- a/test/test/pytools/test_sphinx.py
+++ b/test/test/pytools/test_sphinx.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Dict, Generic, Type, TypeVar
+from typing import Dict, Generic, Optional, Type, TypeVar
 
 import pytest
 
@@ -10,14 +10,22 @@ from pytools.viz.distribution.base import ECDFStyle
 
 log = logging.getLogger(__name__)
 
+S = TypeVar("S")
 T = TypeVar("T")
 U = TypeVar("U")
 V = TypeVar("V")
 
 
 class A(Generic[T, U]):
-    def f(self, x: Type[T]) -> U:
+    def f(self: S, x: Type[T]) -> U:
         pass
+
+    def g(self: S) -> Optional[S]:
+        pass
+
+    @classmethod
+    def h(cls: Type[S]) -> S:
+        return cls()
 
 
 class B(A[U, int], Generic[U, V]):
@@ -52,14 +60,25 @@ def test_resolve_generic_class_parameters() -> None:
 
     resolve_generic_class_parameters.process(app=None, obj=A, bound_method=False)
     resolve_generic_class_parameters.process(app=None, obj=A.f, bound_method=False)
-    assert A.f.__annotations__ == {"x": Type[T], "return": U}
+    assert A.f.__annotations__ == {"self": A, "x": Type[T], "return": U}
+    resolve_generic_class_parameters.process(app=None, obj=A.g, bound_method=False)
+    assert A.g.__annotations__ == {"self": A, "return": Optional[A]}
+
+    resolve_generic_class_parameters.process(app=None, obj=A.h, bound_method=False)
+    assert A.h.__annotations__ == {"cls": Type[A], "return": A}
 
     resolve_generic_class_parameters.process(app=None, obj=B, bound_method=False)
     resolve_generic_class_parameters.process(app=None, obj=B.f, bound_method=False)
     assert B.f is A.f
-    assert A.f.__annotations__ == {"x": Type[U], "return": int}
+    assert A.f.__annotations__ == {"self": B, "x": Type[U], "return": int}
+    resolve_generic_class_parameters.process(app=None, obj=B.g, bound_method=False)
+    assert B.g is A.g
+    assert A.g.__annotations__ == {"self": B, "return": Optional[B]}
+    resolve_generic_class_parameters.process(app=None, obj=B.h, bound_method=False)
+    assert B.h is not A.h
+    assert B.h.__annotations__ == {"cls": Type[B], "return": B}
 
     resolve_generic_class_parameters.process(app=None, obj=C, bound_method=False)
     resolve_generic_class_parameters.process(app=None, obj=C.f, bound_method=False)
     assert C.f is A.f
-    assert A.f.__annotations__ == {"x": Type[str], "return": int}
+    assert A.f.__annotations__ == {"self": C, "x": Type[str], "return": int}


### PR DESCRIPTION
_pytools_ provides Sphinx handler `ResolveGenericClassParameters` that resolves type variables for more legible Sphinx documentation.

This PR adds the ability to resolve type variables introduced by the `self` parameter of methods and the `cls` parameter of class methods.

As an example, consider for following (hypothetical) class definitions:

```python
T = TypeVar("T")

class A:

    def f(self: T) -> T:
        return self

    @classmethod
    def g(cls: Type[T]) -> T:
        return cls()

class B(A):
    pass
```

Without the class handler, Sphinx would document the signature of `B.f` as _~T -> ~T_, and of `B.g` as _Type[~T] -> ~T_.

With this PR, the signatures change to _B -> B_ and _Type[B] -> B_.
