### PR TITLE
API: add kwarg 'using' to @subsdoc decorator

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,6 +9,13 @@ Release Notes
 2.0.0
 ~~~~~
 
+``pytools.api``
+^^^^^^^^^^^^^^^
+
+- API: decorator @:func:`.subsdoc` has a new optional argument ``using``, indicating
+  an object whose docstring will be used as the basis for creating the substituted
+  docstring of the decorated object
+
 ``pytools.data``
 ^^^^^^^^^^^^^^^^
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,7 +12,7 @@ Release Notes
 ``pytools.api``
 ^^^^^^^^^^^^^^^
 
-- API: decorator @:func:`.subsdoc` has a new optional argument ``using``, indicating
+- API: decorator :func:`.subsdoc` has a new optional argument ``using``, indicating
   an object whose docstring will be used as the basis for creating the substituted
   docstring of the decorated object
 

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -782,8 +782,8 @@ def subsdoc(
 
     :param pattern: a regular expression for the pattern to match
     :param replacement: the replacement for substrings matching the pattern
-    :param using: inherit the docstring from the given object and apply the
-        substitution to that docstring
+    :param using: get the docstring from the given object as the basis for the
+        substitution
     :return: the parameterized decorator
     """
 

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -752,18 +752,6 @@ def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
 
         match_found = False
 
-        def _get_docstring(m: Any) -> str:
-            try:
-                return m.__func__.__doc__
-            except AttributeError:
-                return m.__doc__
-
-        def _set_docstring(m: Any, d: str) -> None:
-            try:
-                m.__func__.__doc__ = d
-            except AttributeError:
-                m.__doc__ = d
-
         if _cls.__doc__ == match:
             _cls.__doc__ = _cls.mro()[1].__doc__
             match_found = True
@@ -771,10 +759,7 @@ def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
         for name, member in vars(_cls).items():
             doc = _get_docstring(member)
             if doc == match:
-                _set_docstring(
-                    member,
-                    _get_docstring(getattr(super(_cls, _cls), name, None)),
-                )
+                _set_docstring(member, _get_inherited_docstring(_cls, name))
                 match_found = True
 
         if not match_found:
@@ -788,24 +773,34 @@ def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
     return _inheritdoc_inner
 
 
-def subsdoc(*, pattern: str, replacement: str) -> Callable[[T], T]:
+def subsdoc(
+    *, pattern: str, replacement: str, using: Optional[Any] = None
+) -> Callable[[T], T]:
     """
     Decorator that matches a given pattern in the decorated object's docstring, and
     substitutes it with the given replacement string (see :func:`re.sub`)
 
     :param pattern: a regular expression for the pattern to match
     :param replacement: the replacement for substrings matching the pattern
+    :param using: inherit the docstring from the given object and apply the
+        substitution to that docstring
     :return: the parameterized decorator
     """
 
     def _decorate(_obj: T) -> T:
-        if not isinstance(_obj.__doc__, str):
-            raise ValueError(f"docstring of {_obj!r} is not a string: {_obj.__doc__!r}")
-        _obj.__doc__, n = re.subn(pattern, replacement, _obj.__doc__)
+        origin = _obj if using is None else using
+        docstring_original = _get_docstring(origin)
+        if not isinstance(docstring_original, str):
+            raise ValueError(
+                f"docstring of {origin!r} is not a string: {docstring_original!r}"
+            )
+        docstring_substituted, n = re.subn(pattern, replacement, docstring_original)
         if not n:
             raise ValueError(
-                f"subsdoc: pattern {pattern!r} not found in docstring {_obj.__doc__!r}"
+                f"subsdoc: pattern {pattern!r} "
+                f"not found in docstring {docstring_original!r}"
             )
+        _set_docstring(_obj, docstring_substituted)
         return _obj
 
     if not (isinstance(pattern, str)):
@@ -877,3 +872,27 @@ def update_forward_references(
 
 
 __tracker.validate()
+
+
+def _get_docstring(obj: Any) -> str:
+    # get the docstring of the given object
+
+    try:
+        return obj.__func__.__doc__
+    except AttributeError:
+        return obj.__doc__
+
+
+def _set_docstring(obj: Any, docstring: str) -> None:
+    # set the docstring of the given object
+
+    try:
+        obj.__func__.__doc__ = docstring
+    except AttributeError:
+        obj.__doc__ = docstring
+
+
+def _get_inherited_docstring(child_class: type, attr_name: str) -> Optional[str]:
+    # get the docstring for a given attribute from the base class of the given class
+
+    return _get_docstring(getattr(super(child_class, child_class), attr_name, None))

--- a/test/test/pytools/test_api.py
+++ b/test/test/pytools/test_api.py
@@ -46,6 +46,12 @@ def test_subsdoc() -> None:
 
     assert _A._f.__doc__ == "A5C aac A3C"
 
+    @subsdoc(pattern="A5C", replacement="Foo", using=_A._f)
+    def _g() -> None:
+        pass
+
+    assert _g.__doc__ == "Foo aac A3C"
+
 
 def test_collection_conversions() -> None:
     assert to_set(1) == {1}


### PR DESCRIPTION
This PR adds new keyword argument `using` to the `@subsdoc` decorator, indicating an object whose docstring will be used as the basis for creating the substituted docstring of the decorated object.

This is useful for creating docstrings that are variations of docstrings for similar classes or functions.
