### PR TITLE
API: add new arg optional in pytools.api.to_… functions

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,6 +9,13 @@ Release Notes
 2.0.0
 ~~~~~
 
+``pytools.api``
+^^^^^^^^^^^^^^^
+
+- API: decorator @:func:`.subsdoc` has a new optional argument ``using``, indicating
+  an object whose docstring will be used as the basis for creating the substituted
+  docstring of the decorated object
+
 ``pytools.data``
 ^^^^^^^^^^^^^^^^
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,7 +12,7 @@ Release Notes
 ``pytools.api``
 ^^^^^^^^^^^^^^^
 
-- API: decorator @:func:`.subsdoc` has a new optional argument ``using``, indicating
+- API: decorator :func:`.subsdoc` has a new optional argument ``using``, indicating
   an object whose docstring will be used as the basis for creating the substituted
   docstring of the decorated object
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,8 @@ Release Notes
 ``pytools.api``
 ^^^^^^^^^^^^^^^
 
+- API: collection validation/conversion functions :func:`.to_set`, :func:`.to_tuple`,
+  :func:`.to_list`, and :func:`.to_collection` have a new argument ``optional``
 - API: decorator :func:`.subsdoc` has a new optional argument ``using``, indicating
   an object whose docstring will be used as the basis for creating the substituted
   docstring of the decorated object

--- a/src/pytools/api/__init__.py
+++ b/src/pytools/api/__init__.py
@@ -2,5 +2,7 @@
 Basic tools for API development, supporting documentation, deprecation,
 and run-time validation.
 """
+from ._alltracker import *
 from ._api import *
+from ._decorators import *
 from ._doc_validator import *

--- a/src/pytools/api/_alltracker.py
+++ b/src/pytools/api/_alltracker.py
@@ -1,0 +1,358 @@
+"""
+Core implementation of :mod:`pytools.api`.
+"""
+
+import logging
+import re
+from collections import deque
+from types import FunctionType
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Deque,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    TypeVar,
+    Union,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "AllTracker",
+    "public_module_prefix",
+    "update_forward_references",
+]
+
+
+#
+# Type variables
+#
+
+T = TypeVar("T")
+T_Collection = TypeVar("T_Collection", bound=Collection)
+T_Callable = TypeVar("T_Callable", bound=Callable)
+T_Iterable = TypeVar("T_Iterable", bound=Iterable)
+T_Type = TypeVar("T_Type", bound=type)
+
+
+#
+# The AllTracker, used to check that __all__ includes all publicly defined symbols
+#
+
+
+class AllTracker:
+    """
+    Track global, public items defined in a module and validate that all eligible items
+    have been included in the ``__all__`` variable.
+
+    Items will be tracked if:
+
+    - their name does not start with an underscore character
+    - they are defined after the :class:`.AllTracker` instance has been created
+
+    The underlying idea (and widely used pattern in GAMMA packages) is to define all
+    items in one or more private submodules, export all public items using the
+    ``__all__`` keyword, and import them into a public package one level up
+    (usually the package's ``__init__.py``).
+
+    This ensures a clean namespace in the public package, uncluttered by any imports
+    used in the private module.
+
+    The tracker also performs additional checks to validate the eligibility of
+    definitions for being exported:
+
+    - constant definitions should not be exported, as this will pose difficulties
+      with Sphinx documentation and - from a design perspective - provides less context
+      than defining constants inside classes
+    - definitions exported from other modules should not be re-exported by the importing
+      module
+
+    These validation checks can be overridden if required in special cases.
+    """
+
+    #: if ``True``, automatically replace all forward
+    #: type references in function annotations with the referenced classes;
+    #: see :func:`.update_forward_references`
+    update_forward_references: bool
+
+    #: if ``True``, allow exporting public global constants in ``__all__``;
+    #: these typically have no ``__module__`` or ``__doc__`` attributes and will
+    #: not be properly rendered in generated documentation
+    allow_global_constants: bool
+
+    #: if ``True``, allow exporting definitions in ``__all__`` even if they have been
+    #: imported from another module
+    allow_imported_definitions: bool
+
+    # noinspection PyShadowingNames
+    def __init__(
+        self,
+        globals_: Dict[str, Any],
+        *,
+        public_module: Optional[str] = None,
+        update_forward_references: bool = True,
+        allow_global_constants: bool = False,
+        allow_imported_definitions: bool = False,
+    ) -> None:
+        """
+        :param globals_: the dictionary of global variables returned by calling
+            :meth:`._globals` in the current module scope
+        :param public_module: full name of the public module that will export the items
+            managed by this tracker
+        :param update_forward_references: if ``True``, automatically replace all forward
+            type references in function annotations with the referenced classes; see
+            :func:`.update_forward_references`
+            (default: ``True``)
+        :param allow_global_constants: if ``True``, allow exporting public global
+            constants in ``__all__``;
+            these typically have no ``__module__`` or ``__doc__`` attributes and will
+            not be properly rendered in generated documentation (default: ``False``)
+        :param allow_imported_definitions: if ``True``, allow exporting definitions in
+            ``__all__`` even if they have been imported from another module
+            (default: ``False``)
+        """
+        self._globals = globals_
+        self._imported = set(globals_.keys())
+
+        try:
+            self._module = module = globals_["__name__"]
+        except KeyError:
+            raise ValueError("arg globals_ does not define module name in __name__")
+
+        if not public_module:
+            public_module = public_module_prefix(module)
+
+        self.public_module = globals_["__publicmodule__"] = public_module
+
+        self.update_forward_references = update_forward_references
+        self.allow_global_constants = allow_global_constants
+        self.allow_imported_definitions = allow_imported_definitions
+
+    #: Full name of the public module that will export the items managed by this
+    #: tracker.
+    public_module: str
+
+    def validate(self) -> None:
+        """
+        Validate that all eligible items that were defined since the creation of this
+        tracker are listed in the ``__all__`` variable.
+
+        :raise AssertionError: if ``__all__`` is not as expected, or if one or more
+            definitions do not meet the required criteria to be exported (
+        """
+        all_expected = self.get_tracked()
+
+        globals_ = self._globals
+
+        if set(globals_.get("__all__", [])) != set(all_expected):
+            raise AssertionError(
+                "missing or unexpected all declaration, "
+                f"expected:\n__all__ = {all_expected}"
+            )
+
+        def _qualname(_obj: Any) -> str:
+            try:
+                return _obj.__qualname__
+            except AttributeError:
+                try:
+                    return _obj.__name__
+                except AttributeError:
+                    return repr(_obj)
+
+        module = self._module
+        public_module = self.public_module
+        allow_global_constants = self.allow_global_constants
+        forbid_imported_definitions = not self.allow_imported_definitions
+
+        for name in all_expected:
+            obj = globals_[name]
+
+            # check that the object was defined locally
+            try:
+                obj_module = obj.__module__
+            except AttributeError:
+                if allow_global_constants:
+                    obj_module = None
+                else:
+                    raise AssertionError(
+                        f"exporting a global constant is not permitted: {obj!r}"
+                    )
+
+            if forbid_imported_definitions and obj_module and obj_module != module:
+                raise AttributeError(
+                    f"{_qualname(obj)} is exported by module {module} "
+                    f"but defined in module {obj_module}"
+                )
+
+            # set public module field
+            try:
+                obj.__publicmodule__ = public_module
+            except AttributeError:
+                # objects without a __dict__ will not permit setting the public module
+                pass
+
+            if self.update_forward_references:
+                # update forward references in annotations
+                update_forward_references(obj, globals_=globals_)
+
+    def get_tracked(self) -> List[str]:
+        """
+        List the names of all locally tracked, public items.
+
+        :return: the list of object names, sorted alphabetically
+        """
+        return sorted(filter(self._is_eligible, self._globals))
+
+    def is_tracked(self, name: str, item: Any) -> bool:
+        """
+        Check if the given item is tracked by this tracker under the given name.
+
+        :param name: the name of the item in the tracker's global namespace
+        :param item: the item referred to by the name
+        :return: ``True`` if the given item is tracked by this tracker under the given
+            name; ``False`` otherwise
+        """
+        try:
+            return self._globals[name] is item and self._is_eligible(name)
+        except KeyError:
+            return False
+
+    def _is_eligible(self, name: str) -> bool:
+        # check if the given item is eligible for tracking by this tracker
+        return not (name.startswith("_") or name in self._imported)
+
+    def __getitem__(self, name: str) -> Any:
+        # get a tracked item by name
+
+        item = self._globals[name]
+        if self._is_eligible(name=name):
+            return item
+        else:
+            raise KeyError(name)
+
+
+# regular expression to extract the public prefix of a private module
+# this is the module path up to the first submodule with a leading underscore
+# noinspection RegExpUnnecessaryNonCapturingGroup
+__RE_PUBLIC_MODULE = re.compile(
+    # start of match group for the public part of the module path
+    r"("
+    # first module component must not start with '_')
+    r"(?:[a-zA-Z]\w+)"
+    # then as many path components as can be matched non-greedily …)
+    r"(?:\.\w+)*?"
+    # but when we hit the first private path component, we stop matching the
+    # public part of the path …
+    r")"
+    # … and match the rest as the private path
+    r"(?:\._\w*(?:\.\w+)*)?"
+)
+
+
+def public_module_prefix(module_name: str) -> str:
+    """
+    Get the public prefix of the given module name.
+
+    A module name is composed of one or more identifiers, separated by ``.`` operators.
+    The public prefix is the module name including all identifiers up to, and excluding,
+    the first identifier starting with an underscore character (``_``) .
+    If there is no such identifier, then the public prefix is the same as the full
+    module name.
+    If the first identifier starts with a ``_``, then the public prefix is not defined.
+
+    For example:
+
+    - the public module prefix of ``a.b._c.d._e`` is ``a.b``
+    - the public module prefix of ``a.b`` is ``a.b``
+    - the public module prefix of ``_a.b.c`` is undefined
+
+    :param module_name: the module name for which to get the public prefix
+    :return: the public prefix
+    :raise ValueError: the public prefix is undefined
+    """
+    match = __RE_PUBLIC_MODULE.fullmatch(module_name)
+    if not match:
+        raise ValueError(f"cannot infer public module path from module {module_name}")
+    return match[1]
+
+
+#
+# Ensure all symbols introduced below are included in __all__
+#
+
+__tracker = AllTracker(globals())
+# we forget that class AllTracker itself is already defined, because we want to include
+# it in the __all__ statement
+# noinspection PyProtectedMember
+__tracker._imported.remove(AllTracker.__name__)
+# noinspection PyProtectedMember
+__tracker._imported.remove(public_module_prefix.__name__)
+
+
+def update_forward_references(
+    obj: Union[type, FunctionType], *, globals_: Dict[str, Any]
+) -> None:
+    """
+    Replace all forward references with their referenced classes.
+
+    :param obj: a function or class
+    :param globals_: a global namespace to search the referenced classes in
+    """
+
+    def _parse_cls_with_generic_arguments(cls: str) -> type:
+        def _parse(cls_tokens: Deque[str]) -> type:
+            real_cls = eval(cls_tokens.popleft(), globals_)
+            if cls_tokens and cls_tokens[0] not in ",]":
+                real_args: List[type] = list()
+                sep = cls_tokens.popleft()
+                if sep != "[":
+                    raise TypeError(
+                        f"invalid separator for generic type arguments: {sep}"
+                    )
+                while True:
+                    real_args.append(_parse(cls_tokens))
+                    sep = cls_tokens.popleft()
+                    if sep == "]":
+                        break
+                    elif sep != ",":
+                        raise TypeError(
+                            f"invalid separator for generic type arguments: {sep}"
+                        )
+                return real_cls.__getitem__(tuple(real_args))
+            else:
+                return real_cls
+
+        try:
+            return _parse(deque(map(str.strip, re.split(r"([,\[\]])", cls))))
+        except TypeError as e:
+            raise TypeError(f"invalid type syntax in forward reference: {cls}") from e
+
+    # keep track of classes we already visited to prevent infinite recursion
+    visited: Set[type] = set()
+
+    def _update(_obj: Any) -> None:
+        if isinstance(_obj, type):
+            if _obj not in visited:
+                visited.add(_obj)
+                for member in vars(_obj).values():
+                    _update(member)
+                _update_annotations(getattr(_obj, "__annotations__", None))
+
+        elif isinstance(_obj, FunctionType):
+            _update_annotations(_obj.__annotations__)
+
+    def _update_annotations(annotations: Optional[Dict[str, Any]]):
+        if annotations:
+            for arg, cls in annotations.items():
+                if isinstance(cls, str):
+                    annotations[arg] = _parse_cls_with_generic_arguments(cls)
+
+    _update(obj)
+
+
+__tracker.validate()

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -782,8 +782,8 @@ def subsdoc(
 
     :param pattern: a regular expression for the pattern to match
     :param replacement: the replacement for substrings matching the pattern
-    :param using: inherit the docstring from the given object and apply the
-        substitution to that docstring
+    :param using: get the docstring from the given object as the basis for the
+        substitution
     :return: the parameterized decorator
     """
 

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -353,7 +353,7 @@ def is_list_like(obj: Any) -> bool:
 def to_tuple(
     values: Union[Iterable[T], T, None],
     *,
-    element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    element_type: Optional[Union[Type[T], Tuple[Type[T], ...]]] = None,
     optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Tuple[T, ...]:
@@ -389,7 +389,7 @@ def to_tuple(
 def to_list(
     values: Union[Iterable[T], T, None],
     *,
-    element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    element_type: Optional[Union[Type[T], Tuple[Type[T], ...]]] = None,
     optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> List[T]:
@@ -425,7 +425,7 @@ def to_list(
 def to_set(
     values: Union[Iterable[T], T, None],
     *,
-    element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    element_type: Optional[Union[Type[T], Tuple[Type[T], ...]]] = None,
     optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Set[T]:
@@ -461,7 +461,7 @@ def to_set(
 def to_collection(
     values: Union[Iterable[T], T, None],
     *,
-    element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    element_type: Optional[Union[Type[T], Tuple[Type[T], ...]]] = None,
     optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Collection[T]:
@@ -498,7 +498,7 @@ def _to_collection(
     *,
     collection_type: Optional[Type[Collection]],
     new_collection_type: Type[T_Collection],
-    element_type: Optional[Union[Type[T], Tuple[Type, ...]]],
+    element_type: Optional[Union[Type[T], Tuple[Type[T], ...]]] = None,
     optional: bool,
     arg_name: Optional[str],
 ) -> T_Collection:
@@ -535,7 +535,7 @@ def _to_collection(
 def validate_type(
     value: T,
     *,
-    expected_type: Union[Type[T], Tuple[Type, ...]],
+    expected_type: Union[Type[T], Tuple[Type[T], ...]],
     optional: bool = False,
     name: Optional[str] = None,
 ) -> T:
@@ -586,7 +586,7 @@ def validate_type(
 def validate_element_types(
     iterable: T_Iterable,
     *,
-    expected_type: Union[Type, Tuple[Type, ...]],
+    expected_type: Union[type, Tuple[type, ...]],
     optional: bool = False,
     name: Optional[str] = None,
 ) -> T_Iterable:

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -24,6 +24,7 @@ import pandas as pd
 import typing_inspect
 
 from ._alltracker import AllTracker
+from ._decorators import subsdoc
 
 log = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ def to_tuple(
     Return the given values as a tuple.
 
     - if arg `values` is a tuple, return arg `values` unchanged
-    - if arg `values` is an iterable other than a tuple, return a list of its elements
+    - if arg `values` is an iterable other than a tuple, return a tuple of its elements
     - if arg `values` is not an iterable, return a tuple with the value as its only
       element
 
@@ -115,7 +116,8 @@ def to_tuple(
     :param element_type: expected type of the values, or a tuple of alternative types
         of which each value must match at least one
     :param optional: if ``True``, return an empty tuple when ``None`` is passed as
-        arg ``values``; otherwise, raise a :class:`.TypeError`
+        arg ``values``; otherwise, return a tuple with ``None`` as its only element
+        unless this conflicts with arg ``element_type``
     :param arg_name: name of the argument as which the values were passed to a function
         or method; used when composing the :class:`TypeError` message
     :return: the values as a tuple
@@ -132,6 +134,7 @@ def to_tuple(
     )
 
 
+@subsdoc(pattern="tuple", replacement="list", using=to_tuple)
 def to_list(
     values: Union[Iterable[T], T, None],
     *,
@@ -139,24 +142,7 @@ def to_list(
     optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> List[T]:
-    """
-    Return the given values as a list.
-
-    - if arg `values` is a list, return arg `values` unchanged
-    - if arg `values` is an iterable other than a list, return a list of its elements
-    - if arg `values` is not an iterable, return a list with the value as its only
-      element
-
-    :param values: one or more elements to return as a list
-    :param element_type: expected type of the values, or a tuple of alternative types
-        of which each value must match at least one
-    :param optional: if ``True``, return an empty tuple when ``None`` is passed as
-        arg ``values``; otherwise, raise a :class:`.TypeError`
-    :param arg_name: name of the argument as which the values were passed to a function
-        or method; used when composing the :class:`TypeError` message
-    :return: the values as a list
-    :raise TypeError: one or more values did not match the expected type(s)
-    """
+    """[will be substituted]"""
 
     return _to_collection(
         values=values,
@@ -168,6 +154,7 @@ def to_list(
     )
 
 
+@subsdoc(pattern="tuple", replacement="set", using=to_tuple)
 def to_set(
     values: Union[Iterable[T], T, None],
     *,
@@ -175,24 +162,7 @@ def to_set(
     optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Set[T]:
-    """
-    Return the given values as a set.
-
-    - if arg `values` is a set, return arg `values` unchanged
-    - if arg `values` is an iterable other than a set, return a set of its elements
-    - if arg `values` is not an iterable, return a set with the value as its only
-      element
-
-    :param values: one or more elements to return as a set
-    :param element_type: expected type of the values, or a tuple of alternative types
-        of which each value must match at least one
-    :param optional: if ``True``, return an empty set when ``None`` is passed as
-        arg ``values``; otherwise, raise a :class:`.TypeError`
-    :param arg_name: name of the argument as which the values were passed to a function
-        or method; used when composing the :class:`TypeError` message
-    :return: the values as a set
-    :raise TypeError: one or more values did not match the expected type(s)
-    """
+    """[will be substituted]"""
 
     return _to_collection(
         values=values,
@@ -204,6 +174,13 @@ def to_set(
     )
 
 
+@subsdoc(pattern="iterable other than a collection", replacement="iterable")
+@subsdoc(pattern="return (a|an empty) collection", replacement=r"return \1 tuple")
+@subsdoc(
+    pattern=r"(given values as a collection)",
+    replacement=r"\1, i.e., an iterable container",
+)
+@subsdoc(pattern="tuple", replacement="collection", using=to_tuple)
 def to_collection(
     values: Union[Iterable[T], T, None],
     *,
@@ -211,24 +188,7 @@ def to_collection(
     optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Collection[T]:
-    """
-    Return the given values as a collection, i.e., an iterable container.
-
-    - if arg `values` is a collection, return arg `values` unchanged
-    - if arg `values` is an iterator, return a tuple with its elements
-    - if arg `values` is not an iterable, return a tuple with the value as its only
-      element
-
-    :param values: one or more elements to return as a collection
-    :param element_type: expected type of the values, or a tuple of alternative types
-        of which each value must match at least one
-    :param optional: if ``True``, return an empty tuple when ``None`` is passed as
-        arg ``values``; otherwise, raise a :class:`.TypeError`
-    :param arg_name: name of the argument as which the values were passed to a function
-        or method; used when composing the :class:`TypeError` message
-    :return: the values as a collection
-    :raise TypeError: one or more values did not match the expected type(s)
-    """
+    """[will be substituted]"""
     return _to_collection(
         values=values,
         collection_type=None,

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -3,17 +3,12 @@ Core implementation of :mod:`pytools.api`.
 """
 
 import logging
-import re
 import warnings
-from collections import deque
 from functools import wraps
-from types import FunctionType
 from typing import (
     Any,
     Callable,
     Collection,
-    Deque,
-    Dict,
     Iterable,
     List,
     Optional,
@@ -28,22 +23,19 @@ import numpy as np
 import pandas as pd
 import typing_inspect
 
+from ._alltracker import AllTracker
+
 log = logging.getLogger(__name__)
 
 __all__ = [
-    "AllTracker",
     "deprecated",
     "deprecation_warning",
     "get_generic_bases",
-    "inheritdoc",
     "is_list_like",
-    "public_module_prefix",
-    "subsdoc",
     "to_collection",
     "to_list",
     "to_set",
     "to_tuple",
-    "update_forward_references",
     "validate_element_types",
     "validate_type",
 ]
@@ -61,257 +53,11 @@ T_Type = TypeVar("T_Type", bound=type)
 
 
 #
-# The AllTracker, used to check that __all__ includes all publicly defined symbols
-#
-
-
-class AllTracker:
-    """
-    Track global, public items defined in a module and validate that all eligible items
-    have been included in the ``__all__`` variable.
-
-    Items will be tracked if:
-
-    - their name does not start with an underscore character
-    - they are defined after the :class:`.AllTracker` instance has been created
-
-    The underlying idea (and widely used pattern in GAMMA packages) is to define all
-    items in one or more private submodules, export all public items using the
-    ``__all__`` keyword, and import them into a public package one level up
-    (usually the package's ``__init__.py``).
-
-    This ensures a clean namespace in the public package, uncluttered by any imports
-    used in the private module.
-
-    The tracker also performs additional checks to validate the eligibility of
-    definitions for being exported:
-
-    - constant definitions should not be exported, as this will pose difficulties
-      with Sphinx documentation and - from a design perspective - provides less context
-      than defining constants inside classes
-    - definitions exported from other modules should not be re-exported by the importing
-      module
-
-    These validation checks can be overridden if required in special cases.
-    """
-
-    #: if ``True``, automatically replace all forward
-    #: type references in function annotations with the referenced classes;
-    #: see :func:`.update_forward_references`
-    update_forward_references: bool
-
-    #: if ``True``, allow exporting public global constants in ``__all__``;
-    #: these typically have no ``__module__`` or ``__doc__`` attributes and will
-    #: not be properly rendered in generated documentation
-    allow_global_constants: bool
-
-    #: if ``True``, allow exporting definitions in ``__all__`` even if they have been
-    #: imported from another module
-    allow_imported_definitions: bool
-
-    # noinspection PyShadowingNames
-    def __init__(
-        self,
-        globals_: Dict[str, Any],
-        *,
-        public_module: Optional[str] = None,
-        update_forward_references: bool = True,
-        allow_global_constants: bool = False,
-        allow_imported_definitions: bool = False,
-    ) -> None:
-        """
-        :param globals_: the dictionary of global variables returned by calling
-            :meth:`._globals` in the current module scope
-        :param public_module: full name of the public module that will export the items
-            managed by this tracker
-        :param update_forward_references: if ``True``, automatically replace all forward
-            type references in function annotations with the referenced classes; see
-            :func:`.update_forward_references`
-            (default: ``True``)
-        :param allow_global_constants: if ``True``, allow exporting public global
-            constants in ``__all__``;
-            these typically have no ``__module__`` or ``__doc__`` attributes and will
-            not be properly rendered in generated documentation (default: ``False``)
-        :param allow_imported_definitions: if ``True``, allow exporting definitions in
-            ``__all__`` even if they have been imported from another module
-            (default: ``False``)
-        """
-        self._globals = globals_
-        self._imported = set(globals_.keys())
-
-        try:
-            self._module = module = globals_["__name__"]
-        except KeyError:
-            raise ValueError("arg globals_ does not define module name in __name__")
-
-        if not public_module:
-            public_module = public_module_prefix(module)
-
-        self.public_module = globals_["__publicmodule__"] = public_module
-
-        self.update_forward_references = update_forward_references
-        self.allow_global_constants = allow_global_constants
-        self.allow_imported_definitions = allow_imported_definitions
-
-    #: Full name of the public module that will export the items managed by this
-    #: tracker.
-    public_module: str
-
-    def validate(self) -> None:
-        """
-        Validate that all eligible items that were defined since the creation of this
-        tracker are listed in the ``__all__`` variable.
-
-        :raise AssertionError: if ``__all__`` is not as expected, or if one or more
-            definitions do not meet the required criteria to be exported (
-        """
-        all_expected = self.get_tracked()
-
-        globals_ = self._globals
-
-        if set(globals_.get("__all__", [])) != set(all_expected):
-            raise AssertionError(
-                "missing or unexpected all declaration, "
-                f"expected:\n__all__ = {all_expected}"
-            )
-
-        def _qualname(_obj: Any) -> str:
-            try:
-                return _obj.__qualname__
-            except AttributeError:
-                try:
-                    return _obj.__name__
-                except AttributeError:
-                    return repr(_obj)
-
-        module = self._module
-        public_module = self.public_module
-        allow_global_constants = self.allow_global_constants
-        forbid_imported_definitions = not self.allow_imported_definitions
-
-        for name in all_expected:
-            obj = globals_[name]
-
-            # check that the object was defined locally
-            try:
-                obj_module = obj.__module__
-            except AttributeError:
-                if allow_global_constants:
-                    obj_module = None
-                else:
-                    raise AssertionError(
-                        f"exporting a global constant is not permitted: {obj!r}"
-                    )
-
-            if forbid_imported_definitions and obj_module and obj_module != module:
-                raise AttributeError(
-                    f"{_qualname(obj)} is exported by module {module} "
-                    f"but defined in module {obj_module}"
-                )
-
-            # set public module field
-            try:
-                obj.__publicmodule__ = public_module
-            except AttributeError:
-                # objects without a __dict__ will not permit setting the public module
-                pass
-
-            if self.update_forward_references:
-                # update forward references in annotations
-                update_forward_references(obj, globals_=globals_)
-
-    def get_tracked(self) -> List[str]:
-        """
-        List the names of all locally tracked, public items.
-
-        :return: the list of object names, sorted alphabetically
-        """
-        return sorted(filter(self._is_eligible, self._globals))
-
-    def is_tracked(self, name: str, item: Any) -> bool:
-        """
-        Check if the given item is tracked by this tracker under the given name.
-
-        :param name: the name of the item in the tracker's global namespace
-        :param item: the item referred to by the name
-        :return: ``True`` if the given item is tracked by this tracker under the given
-            name; ``False`` otherwise
-        """
-        try:
-            return self._globals[name] is item and self._is_eligible(name)
-        except KeyError:
-            return False
-
-    def _is_eligible(self, name: str) -> bool:
-        # check if the given item is eligible for tracking by this tracker
-        return not (name.startswith("_") or name in self._imported)
-
-    def __getitem__(self, name: str) -> Any:
-        # get a tracked item by name
-
-        item = self._globals[name]
-        if self._is_eligible(name=name):
-            return item
-        else:
-            raise KeyError(name)
-
-
-# regular expression to extract the public prefix of a private module
-# this is the module path up to the first submodule with a leading underscore
-# noinspection RegExpUnnecessaryNonCapturingGroup
-__RE_PUBLIC_MODULE = re.compile(
-    # start of match group for the public part of the module path
-    r"("
-    # first module component must not start with '_')
-    r"(?:[a-zA-Z]\w+)"
-    # then as many path components as can be matched non-greedily …)
-    r"(?:\.\w+)*?"
-    # but when we hit the first private path component, we stop matching the
-    # public part of the path …
-    r")"
-    # … and match the rest as the private path
-    r"(?:\._\w*(?:\.\w+)*)?"
-)
-
-
-def public_module_prefix(module_name: str) -> str:
-    """
-    Get the public prefix of the given module name.
-
-    A module name is composed of one or more identifiers, separated by ``.`` operators.
-    The public prefix is the module name including all identifiers up to, and excluding,
-    the first identifier starting with an underscore character (``_``) .
-    If there is no such identifier, then the public prefix is the same as the full
-    module name.
-    If the first identifier starts with a ``_``, then the public prefix is not defined.
-
-    For example:
-
-    - the public module prefix of ``a.b._c.d._e`` is ``a.b``
-    - the public module prefix of ``a.b`` is ``a.b``
-    - the public module prefix of ``_a.b.c`` is undefined
-
-    :param module_name: the module name for which to get the public prefix
-    :return: the public prefix
-    :raise ValueError: the public prefix is undefined
-    """
-    match = __RE_PUBLIC_MODULE.fullmatch(module_name)
-    if not match:
-        raise ValueError(f"cannot infer public module path from module {module_name}")
-    return match[1]
-
-
-#
 # Ensure all symbols introduced below are included in __all__
 #
 
 __tracker = AllTracker(globals())
-# we forget that class AllTracker itself is already defined, because we want to include
-# it in the __all__ statement
-# noinspection PyProtectedMember
-__tracker._imported.remove(AllTracker.__name__)
-# noinspection PyProtectedMember
-__tracker._imported.remove(public_module_prefix.__name__)
+
 
 #
 # Functions
@@ -737,188 +483,4 @@ def deprecation_warning(message: str, stacklevel: int = 1) -> None:
     warnings.warn(message, FutureWarning, stacklevel=stacklevel + 1)
 
 
-def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
-    """
-    Decorator to inherit docstrings of overridden methods.
-
-    Usage:
-
-    .. code-block:: python
-
-      class A:
-          def my_function(self) -> None:
-          \"""Some documentation\"""
-          # …
-
-      @inheritdoc(match="[see superclass]")
-      class B(A):
-          def my_function(self) -> None:
-          \"""[see superclass]\"""
-          # …
-
-          def my_other_function(self) -> None:
-          \"""This docstring will not be replaced\"""
-          # …
-
-    In this example, the docstring of the ``my_function`` will be replaced with the
-    docstring of the overridden function of the same name, or with ``None`` if no
-    overridden function exists, or if that function has no docstring.
-
-    :param match: the parent docstring will be inherited if the current docstring
-        is equal to match
-    :return: the parameterized decorator
-    """
-
-    def _inheritdoc_inner(_cls: type) -> type:
-        if not type(_cls):
-            raise TypeError(
-                f"@{inheritdoc.__name__} can only decorate classes, "
-                f"not a {type(_cls).__name__}"
-            )
-
-        match_found = False
-
-        if _cls.__doc__ == match:
-            _cls.__doc__ = _cls.mro()[1].__doc__
-            match_found = True
-
-        for name, member in vars(_cls).items():
-            doc = _get_docstring(member)
-            if doc == match:
-                _set_docstring(member, _get_inherited_docstring(_cls, name))
-                match_found = True
-
-        if not match_found:
-            log.warning(
-                f"{inheritdoc.__name__}:"
-                f"no match found for docstring {repr(match)} in class {_cls.__name__}"
-            )
-
-        return _cls
-
-    return _inheritdoc_inner
-
-
-def subsdoc(
-    *, pattern: str, replacement: str, using: Optional[Any] = None
-) -> Callable[[T], T]:
-    """
-    Decorator that matches a given pattern in the decorated object's docstring, and
-    substitutes it with the given replacement string (see :func:`re.sub`)
-
-    :param pattern: a regular expression for the pattern to match
-    :param replacement: the replacement for substrings matching the pattern
-    :param using: get the docstring from the given object as the basis for the
-        substitution
-    :return: the parameterized decorator
-    """
-
-    def _decorate(_obj: T) -> T:
-        origin = _obj if using is None else using
-        docstring_original = _get_docstring(origin)
-        if not isinstance(docstring_original, str):
-            raise ValueError(
-                f"docstring of {origin!r} is not a string: {docstring_original!r}"
-            )
-        docstring_substituted, n = re.subn(pattern, replacement, docstring_original)
-        if not n:
-            raise ValueError(
-                f"subsdoc: pattern {pattern!r} "
-                f"not found in docstring {docstring_original!r}"
-            )
-        _set_docstring(_obj, docstring_substituted)
-        return _obj
-
-    if not (isinstance(pattern, str)):
-        raise ValueError("arg pattern must be a string")
-    if not (isinstance(replacement, str)):
-        raise ValueError("arg replacement must be a string")
-    return _decorate
-
-
-def update_forward_references(
-    obj: Union[type, FunctionType], *, globals_: Dict[str, Any]
-) -> None:
-    """
-    Replace all forward references with their referenced classes.
-
-    :param obj: a function or class
-    :param globals_: a global namespace to search the referenced classes in
-    """
-
-    def _parse_cls_with_generic_arguments(cls: str) -> type:
-        def _parse(cls_tokens: Deque[str]) -> type:
-            real_cls = eval(cls_tokens.popleft(), globals_)
-            if cls_tokens and cls_tokens[0] not in ",]":
-                real_args: List[type] = list()
-                sep = cls_tokens.popleft()
-                if sep != "[":
-                    raise TypeError(
-                        f"invalid separator for generic type arguments: {sep}"
-                    )
-                while True:
-                    real_args.append(_parse(cls_tokens))
-                    sep = cls_tokens.popleft()
-                    if sep == "]":
-                        break
-                    elif sep != ",":
-                        raise TypeError(
-                            f"invalid separator for generic type arguments: {sep}"
-                        )
-                return real_cls.__getitem__(tuple(real_args))
-            else:
-                return real_cls
-
-        try:
-            return _parse(deque(map(str.strip, re.split(r"([,\[\]])", cls))))
-        except TypeError as e:
-            raise TypeError(f"invalid type syntax in forward reference: {cls}") from e
-
-    # keep track of classes we already visited to prevent infinite recursion
-    visited: Set[type] = set()
-
-    def _update(_obj: Any) -> None:
-        if isinstance(_obj, type):
-            if _obj not in visited:
-                visited.add(_obj)
-                for member in vars(_obj).values():
-                    _update(member)
-                _update_annotations(getattr(_obj, "__annotations__", None))
-
-        elif isinstance(_obj, FunctionType):
-            _update_annotations(_obj.__annotations__)
-
-    def _update_annotations(annotations: Optional[Dict[str, Any]]):
-        if annotations:
-            for arg, cls in annotations.items():
-                if isinstance(cls, str):
-                    annotations[arg] = _parse_cls_with_generic_arguments(cls)
-
-    _update(obj)
-
-
 __tracker.validate()
-
-
-def _get_docstring(obj: Any) -> str:
-    # get the docstring of the given object
-
-    try:
-        return obj.__func__.__doc__
-    except AttributeError:
-        return obj.__doc__
-
-
-def _set_docstring(obj: Any, docstring: str) -> None:
-    # set the docstring of the given object
-
-    try:
-        obj.__func__.__doc__ = docstring
-    except AttributeError:
-        obj.__doc__ = docstring
-
-
-def _get_inherited_docstring(child_class: type, attr_name: str) -> Optional[str]:
-    # get the docstring for a given attribute from the base class of the given class
-
-    return _get_docstring(getattr(super(child_class, child_class), attr_name, None))

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -351,9 +351,10 @@ def is_list_like(obj: Any) -> bool:
 
 
 def to_tuple(
-    values: Union[Iterable[T], T],
+    values: Union[Iterable[T], T, None],
     *,
     element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Tuple[T, ...]:
     """
@@ -367,6 +368,8 @@ def to_tuple(
     :param values: one or more elements to return as a tuple
     :param element_type: expected type of the values, or a tuple of alternative types
         of which each value must match at least one
+    :param optional: if ``True``, return an empty tuple when ``None`` is passed as
+        arg ``values``; otherwise, raise a :class:`.TypeError`
     :param arg_name: name of the argument as which the values were passed to a function
         or method; used when composing the :class:`TypeError` message
     :return: the values as a tuple
@@ -378,14 +381,16 @@ def to_tuple(
         collection_type=tuple,
         new_collection_type=tuple,
         element_type=element_type,
+        optional=optional,
         arg_name=arg_name,
     )
 
 
 def to_list(
-    values: Union[Iterable[T], T],
+    values: Union[Iterable[T], T, None],
     *,
     element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> List[T]:
     """
@@ -399,6 +404,8 @@ def to_list(
     :param values: one or more elements to return as a list
     :param element_type: expected type of the values, or a tuple of alternative types
         of which each value must match at least one
+    :param optional: if ``True``, return an empty tuple when ``None`` is passed as
+        arg ``values``; otherwise, raise a :class:`.TypeError`
     :param arg_name: name of the argument as which the values were passed to a function
         or method; used when composing the :class:`TypeError` message
     :return: the values as a list
@@ -410,14 +417,16 @@ def to_list(
         collection_type=list,
         new_collection_type=list,
         element_type=element_type,
+        optional=optional,
         arg_name=arg_name,
     )
 
 
 def to_set(
-    values: Union[Iterable[T], T],
+    values: Union[Iterable[T], T, None],
     *,
     element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Set[T]:
     """
@@ -431,6 +440,8 @@ def to_set(
     :param values: one or more elements to return as a set
     :param element_type: expected type of the values, or a tuple of alternative types
         of which each value must match at least one
+    :param optional: if ``True``, return an empty set when ``None`` is passed as
+        arg ``values``; otherwise, raise a :class:`.TypeError`
     :param arg_name: name of the argument as which the values were passed to a function
         or method; used when composing the :class:`TypeError` message
     :return: the values as a set
@@ -442,14 +453,16 @@ def to_set(
         collection_type=set,
         new_collection_type=set,
         element_type=element_type,
+        optional=optional,
         arg_name=arg_name,
     )
 
 
 def to_collection(
-    values: Union[Iterable[T], T],
+    values: Union[Iterable[T], T, None],
     *,
     element_type: Optional[Union[Type[T], Tuple[Type, ...]]] = None,
+    optional: bool = False,
     arg_name: Optional[str] = None,
 ) -> Collection[T]:
     """
@@ -463,6 +476,8 @@ def to_collection(
     :param values: one or more elements to return as a collection
     :param element_type: expected type of the values, or a tuple of alternative types
         of which each value must match at least one
+    :param optional: if ``True``, return an empty tuple when ``None`` is passed as
+        arg ``values``; otherwise, raise a :class:`.TypeError`
     :param arg_name: name of the argument as which the values were passed to a function
         or method; used when composing the :class:`TypeError` message
     :return: the values as a collection
@@ -473,22 +488,26 @@ def to_collection(
         collection_type=None,
         new_collection_type=tuple,
         element_type=element_type,
+        optional=optional,
         arg_name=arg_name,
     )
 
 
 def _to_collection(
-    values: Union[T, Iterable[T]],
+    values: Union[Iterable[T], T, None],
     *,
     collection_type: Optional[Type[Collection]],
     new_collection_type: Type[T_Collection],
     element_type: Optional[Union[Type[T], Tuple[Type, ...]]],
+    optional: bool,
     arg_name: Optional[str],
 ) -> T_Collection:
 
     elements: T_Collection
 
-    if (
+    if optional and values is None:
+        return new_collection_type()
+    elif (
         isinstance(values, Iterable)
         and not isinstance(values, str)
         and not isinstance(values, bytes)

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -603,6 +603,13 @@ def validate_element_types(
     :raise TypeException: one or more elements of the iterable did not match the
         expected type
     """
+    if isinstance(iterable, (str, bytes)):
+        raise TypeError(
+            f"{name} must not be a string or bytes instance"
+            if name
+            else "expected an iterable other than a string or bytes instance"
+        )
+
     if expected_type is not object:
         if optional:
             expected_type = (

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -752,18 +752,6 @@ def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
 
         match_found = False
 
-        def _get_docstring(m: Any) -> str:
-            try:
-                return m.__func__.__doc__
-            except AttributeError:
-                return m.__doc__
-
-        def _set_docstring(m: Any, d: str) -> None:
-            try:
-                m.__func__.__doc__ = d
-            except AttributeError:
-                m.__doc__ = d
-
         if _cls.__doc__ == match:
             _cls.__doc__ = _cls.mro()[1].__doc__
             match_found = True
@@ -771,10 +759,7 @@ def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
         for name, member in vars(_cls).items():
             doc = _get_docstring(member)
             if doc == match:
-                _set_docstring(
-                    member,
-                    _get_docstring(getattr(super(_cls, _cls), name, None)),
-                )
+                _set_docstring(member, _get_inherited_docstring(_cls, name))
                 match_found = True
 
         if not match_found:
@@ -788,24 +773,34 @@ def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
     return _inheritdoc_inner
 
 
-def subsdoc(*, pattern: str, replacement: str) -> Callable[[T], T]:
+def subsdoc(
+    *, pattern: str, replacement: str, using: Optional[Any] = None
+) -> Callable[[T], T]:
     """
     Decorator that matches a given pattern in the decorated object's docstring, and
     substitutes it with the given replacement string (see :func:`re.sub`)
 
     :param pattern: a regular expression for the pattern to match
     :param replacement: the replacement for substrings matching the pattern
+    :param using: inherit the docstring from the given object and apply the
+        substitution to that docstring
     :return: the parameterized decorator
     """
 
     def _decorate(_obj: T) -> T:
-        if not isinstance(_obj.__doc__, str):
-            raise ValueError(f"docstring of {_obj!r} is not a string: {_obj.__doc__!r}")
-        _obj.__doc__, n = re.subn(pattern, replacement, _obj.__doc__)
+        origin = _obj if using is None else using
+        docstring_original = _get_docstring(origin)
+        if not isinstance(docstring_original, str):
+            raise ValueError(
+                f"docstring of {origin!r} is not a string: {docstring_original!r}"
+            )
+        docstring_substituted, n = re.subn(pattern, replacement, docstring_original)
         if not n:
             raise ValueError(
-                f"subsdoc: pattern {pattern!r} not found in docstring {_obj.__doc__!r}"
+                f"subsdoc: pattern {pattern!r} "
+                f"not found in docstring {docstring_original!r}"
             )
+        _set_docstring(_obj, docstring_substituted)
         return _obj
 
     if not (isinstance(pattern, str)):
@@ -877,3 +872,27 @@ def update_forward_references(
 
 
 __tracker.validate()
+
+
+def _get_docstring(obj: Any) -> str:
+    # get the docstring of the given object
+
+    try:
+        return obj.__func__.__doc__
+    except AttributeError:
+        return obj.__doc__
+
+
+def _set_docstring(obj: Any, docstring: str) -> None:
+    # set the docstring of the given object
+
+    try:
+        obj.__func__.__doc__ = docstring
+    except AttributeError:
+        obj.__doc__ = docstring
+
+
+def _get_inherited_docstring(child_class: type, attr_name: str) -> Optional[str]:
+    # get the docstring for a given attribute from the base class of the given class
+
+    return _get_docstring(getattr(super(child_class, child_class), attr_name, None))

--- a/src/pytools/api/_decorators.py
+++ b/src/pytools/api/_decorators.py
@@ -6,6 +6,8 @@ import logging
 import re
 from typing import Any, Callable, Optional, TypeVar
 
+from pytools.api._alltracker import AllTracker
+
 log = logging.getLogger(__name__)
 
 __all__ = ["inheritdoc", "subsdoc"]
@@ -21,6 +23,7 @@ T_Type = TypeVar("T_Type", bound=type)
 #
 # The AllTracker, used to check that __all__ includes all publicly defined symbols
 #
+__tracker = AllTracker(globals())
 
 
 def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
@@ -120,6 +123,9 @@ def subsdoc(
     if not (isinstance(replacement, str)):
         raise ValueError("arg replacement must be a string")
     return _decorate
+
+
+__tracker.validate()
 
 
 def _get_docstring(obj: Any) -> str:

--- a/src/pytools/api/_decorators.py
+++ b/src/pytools/api/_decorators.py
@@ -1,0 +1,146 @@
+"""
+Core implementation of decorators in :mod:`pytools.api`.
+"""
+
+import logging
+import re
+from typing import Any, Callable, Optional, TypeVar
+
+log = logging.getLogger(__name__)
+
+__all__ = ["inheritdoc", "subsdoc"]
+
+#
+# Type variables
+#
+
+T = TypeVar("T")
+T_Type = TypeVar("T_Type", bound=type)
+
+
+#
+# The AllTracker, used to check that __all__ includes all publicly defined symbols
+#
+
+
+def inheritdoc(*, match: str) -> Callable[[T_Type], T_Type]:
+    """
+    Decorator to inherit docstrings of overridden methods.
+
+    Usage:
+
+    .. code-block:: python
+
+      class A:
+          def my_function(self) -> None:
+          \"""Some documentation\"""
+          # …
+
+      @inheritdoc(match="[see superclass]")
+      class B(A):
+          def my_function(self) -> None:
+          \"""[see superclass]\"""
+          # …
+
+          def my_other_function(self) -> None:
+          \"""This docstring will not be replaced\"""
+          # …
+
+    In this example, the docstring of the ``my_function`` will be replaced with the
+    docstring of the overridden function of the same name, or with ``None`` if no
+    overridden function exists, or if that function has no docstring.
+
+    :param match: the parent docstring will be inherited if the current docstring
+        is equal to match
+    :return: the parameterized decorator
+    """
+
+    def _inheritdoc_inner(_cls: type) -> type:
+        if not type(_cls):
+            raise TypeError(
+                f"@{inheritdoc.__name__} can only decorate classes, "
+                f"not a {type(_cls).__name__}"
+            )
+
+        match_found = False
+
+        if _cls.__doc__ == match:
+            _cls.__doc__ = _cls.mro()[1].__doc__
+            match_found = True
+
+        for name, member in vars(_cls).items():
+            doc = _get_docstring(member)
+            if doc == match:
+                _set_docstring(member, _get_inherited_docstring(_cls, name))
+                match_found = True
+
+        if not match_found:
+            log.warning(
+                f"{inheritdoc.__name__}:"
+                f"no match found for docstring {repr(match)} in class {_cls.__name__}"
+            )
+
+        return _cls
+
+    return _inheritdoc_inner
+
+
+def subsdoc(
+    *, pattern: str, replacement: str, using: Optional[Any] = None
+) -> Callable[[T], T]:
+    """
+    Decorator that matches a given pattern in the decorated object's docstring, and
+    substitutes it with the given replacement string (see :func:`re.sub`)
+
+    :param pattern: a regular expression for the pattern to match
+    :param replacement: the replacement for substrings matching the pattern
+    :param using: get the docstring from the given object as the basis for the
+        substitution
+    :return: the parameterized decorator
+    """
+
+    def _decorate(_obj: T) -> T:
+        origin = _obj if using is None else using
+        docstring_original = _get_docstring(origin)
+        if not isinstance(docstring_original, str):
+            raise ValueError(
+                f"docstring of {origin!r} is not a string: {docstring_original!r}"
+            )
+        docstring_substituted, n = re.subn(pattern, replacement, docstring_original)
+        if not n:
+            raise ValueError(
+                f"subsdoc: pattern {pattern!r} "
+                f"not found in docstring {docstring_original!r}"
+            )
+        _set_docstring(_obj, docstring_substituted)
+        return _obj
+
+    if not (isinstance(pattern, str)):
+        raise ValueError("arg pattern must be a string")
+    if not (isinstance(replacement, str)):
+        raise ValueError("arg replacement must be a string")
+    return _decorate
+
+
+def _get_docstring(obj: Any) -> str:
+    # get the docstring of the given object
+
+    try:
+        return obj.__func__.__doc__
+    except AttributeError:
+        return obj.__doc__
+
+
+def _set_docstring(obj: Any, docstring: str) -> None:
+    # set the docstring of the given object
+
+    try:
+        obj.__func__.__doc__ = docstring
+    except AttributeError:
+        obj.__doc__ = docstring
+
+
+def _get_inherited_docstring(child_class: type, attr_name: str) -> Optional[str]:
+    # get the docstring for a given attribute from the base class of the given class
+
+    return _get_docstring(getattr(super(child_class, child_class), attr_name, None))

--- a/src/pytools/api/_doc_validator.py
+++ b/src/pytools/api/_doc_validator.py
@@ -6,7 +6,6 @@ import importlib
 import logging
 import os
 import re
-import sys
 from glob import glob
 from types import FunctionType, ModuleType
 from typing import (
@@ -51,7 +50,6 @@ __all__ = ["DocValidator"]
 T_NamedElementDefinition = TypeVar(
     "T_NamedElementDefinition", bound=NamedElementDefinition
 )
-
 
 #
 # Ensure all symbols introduced below are included in __all__
@@ -242,9 +240,15 @@ class DocValidator:
             )
 
     def _log_validation_errors(self) -> None:
-        for full_name, errors in self.validation_errors.items():
-            for error in errors:
-                print(f"{full_name}: {error}", file=sys.stderr)
+        if self.validation_errors:
+            log.error(
+                "\n"
+                + "\n".join(
+                    f"{full_name}: {error}"
+                    for full_name, errors in self.validation_errors.items()
+                    for error in errors
+                )
+            )
 
     def _load_modules(self) -> List[ModuleType]:
         # list paths to all python files

--- a/src/pytools/api/_doc_validator.py
+++ b/src/pytools/api/_doc_validator.py
@@ -230,6 +230,10 @@ class DocValidator:
 
         # inspect classes recursively
         for cls in classes:
+            log.debug(
+                f"Inspecting elements of {cls.full_name}: "
+                f"{list(vars(cls.element).keys())}"
+            )
             self._validate_members(
                 members=[
                     attribute

--- a/src/pytools/viz/util/_matplot.py
+++ b/src/pytools/viz/util/_matplot.py
@@ -154,16 +154,20 @@ class FittedText(Text):
             ):
                 super().draw(renderer)
 
+    def set(self, **kwargs: Any) -> None:
+        """
+        Set multiple properties.
+
+        :param kwargs: the properties to set
+        """
+
+        if "width" in kwargs:
+            self.set_width(kwargs.pop("width"))
+        if "height" in kwargs:
+            self.set_height(kwargs.pop("height"))
+        super().set(**kwargs)
+
 
 # check consistency of __all__
 
-assert "set" not in vars(
-    FittedText
-), f"'set' not expected in vars(FittedText): {list(vars(FittedText).keys())}"
-
 __tracker.validate()
-
-assert "set" not in vars(FittedText), (
-    f"'set' not expected in vars(FittedText) after AllTracker validation: "
-    f"{list(vars(FittedText).keys())}"
-)

--- a/src/pytools/viz/util/_matplot.py
+++ b/src/pytools/viz/util/_matplot.py
@@ -157,8 +157,13 @@ class FittedText(Text):
 
 # check consistency of __all__
 
-assert "set" not in vars(FittedText)
+assert "set" not in vars(
+    FittedText
+), f"'set' not expected in vars(FittedText): {list(vars(FittedText).keys())}"
 
 __tracker.validate()
 
-assert "set" not in vars(FittedText)
+assert "set" not in vars(FittedText), (
+    f"'set' not expected in vars(FittedText) after AllTracker validation: "
+    f"{list(vars(FittedText).keys())}"
+)

--- a/src/pytools/viz/util/_matplot.py
+++ b/src/pytools/viz/util/_matplot.py
@@ -157,4 +157,8 @@ class FittedText(Text):
 
 # check consistency of __all__
 
+assert "set" not in vars(FittedText)
+
 __tracker.validate()
+
+assert "set" not in vars(FittedText)

--- a/test/test/pytools/test_api.py
+++ b/test/test/pytools/test_api.py
@@ -80,6 +80,16 @@ def test_collection_conversions() -> None:
     assert to_collection(t) is t
     assert to_collection(d) is d
 
+    assert to_set(None, optional=True) == set()
+    assert to_list(None, optional=True) == []
+    assert to_tuple(None, optional=True) == ()
+    assert to_collection(None, optional=True) == ()
+
+    assert to_set(None) == {None}
+    assert to_list(None) == [None]
+    assert to_tuple(None) == (None,)
+    assert to_collection(None) == (None,)
+
     with pytest.raises(TypeError):
         to_set(1, element_type=str)
     with pytest.raises(TypeError):

--- a/test/test/pytools/test_api.py
+++ b/test/test/pytools/test_api.py
@@ -46,6 +46,12 @@ def test_subsdoc() -> None:
 
     assert _A._f.__doc__ == "A5C aac A3C"
 
+    @subsdoc(pattern="A5C", replacement="Foo", using=_A._f)
+    def _g() -> None:
+        pass
+
+    assert _g.__doc__ == "Foo aac A3C"
+
 
 def test_collection_conversions() -> None:
     assert to_set(1) == {1}

--- a/test/test/pytools/test_api.py
+++ b/test/test/pytools/test_api.py
@@ -112,6 +112,16 @@ def test_collection_conversions() -> None:
     with pytest.raises(TypeError, match=r"^xyz "):
         validate_element_types(iter([1, 2, 3]), expected_type=str, name="xyz")
 
+    with pytest.raises(
+        TypeError, match=r"^xyz must not be a string or bytes instance$"
+    ):
+        validate_element_types("abc", expected_type=str, name="xyz")
+
+    with pytest.raises(
+        TypeError, match=r"^expected an iterable other than a string or bytes instance$"
+    ):
+        validate_element_types("abc", expected_type=str)
+
 
 def test_type_validation() -> None:
     validate_type(3, expected_type=int)


### PR DESCRIPTION
This PR adds a new boolean argument `optional` to collection validation/conversion functions `to_…` in module `pytools.api`. If that argument is set to `True`, then a `None` value is converted to an empty collection.

To prevent cyclical references, this PR also moves decorators `inheritdoc` and `subsdoc` to a separate source file, and `AllTracker` to another separate source file along with two supporting functions. The code being moved is unchanged.

Sequential PR: merge #288 first.