### PR TITLE
BUILD: get the package version in make.py by parsing __init__.py

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,14 @@ Release Notes
 *pytools* 1.1
 -------------
 
+1.1.7
+~~~~~
+
+- BUILD: update the ``make.py`` build script to removes its reliance on importing the
+  actual module just to obtain the build version; instead, ``make.py`` now scans the
+  top-level ``__init__.py`` file for a ``__version__`` declaration.
+
+
 1.1.6
 ~~~~~
 

--- a/make.py
+++ b/make.py
@@ -49,7 +49,7 @@ TOX_BUILD_PATH_SUFFIX = os.path.join("dist", "tox")
 
 PKG_PYTHON = "python"
 
-RE_VERSION_DECLARATION = re.compile(r"__version__\s*=\s*(?:\"([^\"]*)\"|'([^']*)')")
+RE_VERSION_DECLARATION = re.compile(r"\b__version__\s*=\s*(?:\"([^\"]*)\"|'([^']*)')")
 RE_VERSION = re.compile(
     r"(?:\s*(?:[<>]=?|[!~=]=)\s*\d+(?:\.\d+)*(?:a\d*|b\d*|rc\d*|\.\*)?\s*,?)+(?<!,)"
 )


### PR DESCRIPTION
This removes make.py's reliance on being able to import the actual module just to obtain the build version.

Other than making the build process more robust, helps addresse a [new issue with flit](https://github.com/pypa/flit/issues/530) in conjunction with PR BCG-GAMMA/sklearndf#205.