### PR TITLE
BUILD: get the package version in make_base.py by parsing __init__.py

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -8,7 +8,8 @@ Release Notes
 ~~~~~
 
 - BUILD: the ``make_base.py`` build script no longer imports the actual module to obtain
-  the current package version, similarly as introduced for ``make.py` in *pytools* 1.1.7
+  the current package version, similarly as introduced for ``make.py`` in
+  *pytools* 1.1.7
 
 
 1.1.7

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,12 +4,19 @@ Release Notes
 *pytools* 1.1
 -------------
 
+1.1.8
+~~~~~
+
+- BUILD: the ``make_base.py`` build script no longer imports the actual module to obtain
+  the current package version, similarly as introduced for ``make.py` in *pytools* 1.1.7
+
+
 1.1.7
 ~~~~~
 
-- BUILD: update the ``make.py`` build script to removes its reliance on importing the
+- BUILD: update the ``make.py`` build script to remove its reliance on importing the
   actual module just to obtain the build version; instead, ``make.py`` now scans the
-  top-level ``__init__.py`` file for a ``__version__`` declaration.
+  top-level ``__init__.py`` file for a ``__version__`` declaration
 
 
 1.1.6


### PR DESCRIPTION
This PR removes the reliance of `make_base.py` on importing the actual module just to obtain the build version during a sphinx documentation build.

Other than making the build process more robust, helps addresse a [new issue with flit](https://github.com/pypa/flit/issues/530) in conjunction with PR BCG-GAMMA/sklearndf#205.