### PR TITLE
FIX: add missing type call

### DIFF
--- a/src/pytools/sphinx/util/_util.py
+++ b/src/pytools/sphinx/util/_util.py
@@ -68,7 +68,7 @@ __all__ = [
 #
 
 method_descriptor = type(str.__dict__["startswith"])
-wrapper_descriptor = str.__dict__["__add__"]
+wrapper_descriptor = type(str.__dict__["__add__"])
 
 #
 # Ensure all symbols introduced below are included in __all__


### PR DESCRIPTION
When building `sklearndf` docs with `python make.py html` it failed with 
```
isinstance() arg 2 must be a type or tuple of types
``` 
for class `Replace3rdPartyDoc`. This change helped complete building docs.