### PR TITLE
FIX: write all log messages to stderr in make_base.py

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,14 @@ Release Notes
 *pytools* 1.1
 -------------
 
+1.1.10
+~~~~~~
+
+This release addresses additional issues in the release process, focusing on the
+`make_base.py` script for Sphinx builds used across *gamma-pytools*, *sklearndf*, and
+*gamma-facet*.
+
+
 1.1.9
 ~~~~~
 

--- a/make.py
+++ b/make.py
@@ -17,8 +17,14 @@ from urllib.request import pathname2url
 
 import toml
 
-CWD = os.getcwd()
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+
+sys.path.insert(
+    0,
+    os.path.normpath(os.path.join(SCRIPT_DIR, "sphinx", "base")),
+)
+# noinspection PyUnresolvedReferences
+from make_util import get_package_version
 
 FACET_PATH_ENV = "FACET_PATH"
 FACET_PATH_URI_ENV = "FACET_PATH_URI"
@@ -77,30 +83,8 @@ class Builder(metaclass=ABCMeta):
 
         project_root_path = os.path.abspath(os.path.join(projects_root_path, project))
         src_root_path = os.path.join(project_root_path, "src", project)
-        init_path = os.path.join(src_root_path, "__init__.py")
 
-        log(f"Retrieving package version from {init_path}")
-
-        with open(init_path, "rt") as init_file:
-            init_lines = init_file.readlines()
-
-        matches = {
-            match[1] or match[2]
-            for match in (RE_VERSION_DECLARATION.match(line) for line in init_lines)
-            if match
-        }
-
-        if len(matches) == 0:
-            raise RuntimeError(f"No valid __version__ declaration found in {init_path}")
-
-        elif len(matches) > 1:
-            raise RuntimeError(
-                f"Multiple conflicting __version__ declarations found in {init_path}: "
-                f"{matches}"
-            )
-
-        else:
-            package_version = next(iter(matches))
+        package_version = str(get_package_version(package_path=src_root_path))
 
         os.environ[
             FACET_BUILD_PKG_VERSION_ENV.format(project=project.upper())

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -74,7 +74,8 @@ _log.info(f"sys.path = {sys.path}")
 # -- Project information -----------------------------------------------------
 
 project = "pytools"
-copyright = "2021, Boston Consulting Group (BCG)"
+# noinspection PyShadowingBuiltins
+copyright = "2022, Boston Consulting Group (BCG)"
 author = "FACET Team"
 
 # -- General configuration ---------------------------------------------------

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -73,7 +73,7 @@ _log.info(f"sys.path = {sys.path}")
 
 # -- Project information -----------------------------------------------------
 
-project = "pytools"
+project = "<undefined>"  # set by function set_config
 # noinspection PyShadowingBuiltins
 copyright = "2022, Boston Consulting Group (BCG)"
 author = "FACET Team"

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -183,16 +183,15 @@ def _get_package_version() -> str:
     Get the package version for the project being built.
     :return: string with Python package version
     """
-    # NOTE: sphinx-make changes the CWD into sphinx/source
-    #       while FACET's make_base expects a CWD <project>/src
-    #       hence: save current CWD, navigate to <project>/src, then go back
-    cwd = os.getcwd()
-    os.chdir(os.path.join(cwd, os.pardir, os.pardir, "src"))
-    import make_base
+    from make_util import get_package_version
 
-    version_ = str(make_base.get_package_version())
-    os.chdir(cwd)
-    return version_
+    return str(
+        get_package_version(
+            package_path=(
+                os.path.join(os.getcwd(), os.pardir, os.pardir, "src", project)
+            )
+        )
+    )
 
 
 version = _get_package_version()

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -45,13 +45,22 @@ def set_config(
     Add required modules to the python path, and set custom configuration options
     """
 
+    from make_util import get_package_version
+
     globals_["project"] = project
+    globals_["version"] = str(
+        get_package_version(
+            package_path=(
+                os.path.join(os.getcwd(), os.pardir, os.pardir, "src", project)
+            )
+        )
+    )
 
     if html_logo:
         globals_["html_logo"] = html_logo
         globals_["latex_logo"] = html_logo
 
-    modules = set(modules) | {"pytools"}
+    modules = {"pytools", *modules}
     for module in modules:
         module_path = os.path.normpath(os.path.join(_dir_repo_root, module, "src"))
         if module_path not in sys.path:
@@ -73,7 +82,6 @@ _log.info(f"sys.path = {sys.path}")
 
 # -- Project information -----------------------------------------------------
 
-project = "<undefined>"  # set by function set_config
 # noinspection PyShadowingBuiltins
 copyright = "2022, Boston Consulting Group (BCG)"
 author = "FACET Team"
@@ -178,30 +186,13 @@ html_logo = "_static/gamma_logo.jpg"
 # Class documentation to include docstrings both global to the class, and from __init__
 autoclass_content = "both"
 
-
-def _get_package_version() -> str:
-    """
-    Get the package version for the project being built.
-    :return: string with Python package version
-    """
-    from make_util import get_package_version
-
-    return str(
-        get_package_version(
-            package_path=(
-                os.path.join(os.getcwd(), os.pardir, os.pardir, "src", project)
-            )
-        )
-    )
-
-
-version = _get_package_version()
 # -- End of options section ------------------------------------------------------------
 
 
 def setup(app: Sphinx) -> None:
     """
-    Add event handlers to the Sphinx application object
+    Add event handlers to the Sphinx application object.
+
     :param app: the Sphinx application object
     """
 

--- a/sphinx/base/make_util.py
+++ b/sphinx/base/make_util.py
@@ -1,0 +1,45 @@
+"""
+Utility functions for sphinx and package builds.
+"""
+
+import os
+import re
+import sys
+
+from packaging import version as pkg_version
+
+RE_VERSION_DECLARATION = re.compile(r"\b__version__\s*=\s*(?:\"([^\"]*)\"|'([^']*)')")
+
+
+def get_package_version(package_path: str) -> pkg_version.Version:
+    """
+    Retrieve the package version for the project from __init__
+
+    :param package_path: the root directory of the package
+    """
+    init_path = os.path.abspath(os.path.join(package_path, "__init__.py"))
+
+    print(f"Retrieving package version from {init_path}", file=sys.stderr)
+
+    with open(init_path, "rt") as init_file:
+        init_lines = init_file.readlines()
+
+    matches = {
+        match[1] or match[2]
+        for match in (RE_VERSION_DECLARATION.match(line) for line in init_lines)
+        if match
+    }
+
+    if len(matches) == 0:
+        raise RuntimeError(f"No valid __version__ declaration found in {init_path}")
+
+    elif len(matches) > 1:
+        raise RuntimeError(
+            f"Multiple conflicting __version__ declarations found in {init_path}: "
+            f"{matches}"
+        )
+
+    else:
+        package_version = next(iter(matches))
+
+    return pkg_version.parse(package_version)

--- a/src/pytools/__init__.py
+++ b/src/pytools/__init__.py
@@ -1,4 +1,4 @@
 """
 A collection of Python extensions and tools used in BCG GAMMA's open-source libraries.
 """
-__version__ = "1.1.9"
+__version__ = "1.1.10"


### PR DESCRIPTION
Part 2 of fixing GitHub builds, ensuring that also `make_base.py` writes all diagnostic output to `stderr`, not `stdout`.

Also, consolidating redundant code to determine the package version in `make_util.py`, used both by package and sphinx builds.