### PR TITLE
API: replace custom code to parse type hints with call to get_type_hints

### DIFF
--- a/src/pytools/api/doc/_doc.py
+++ b/src/pytools/api/doc/_doc.py
@@ -36,6 +36,13 @@ __all__ = [
 
 T_Type = TypeVar("T_Type", bound=Union[type, FunctionType])
 
+
+#
+# Type constants
+#
+NoneType = type(None)
+
+
 #
 # Ensure all symbols introduced below are included in __all__
 #
@@ -221,11 +228,14 @@ class FunctionDefinition(NamedElementDefinition[FunctionType]):
             if i > 0 or parameter not in {"self", "cls"}
         ]
 
-        if include_return and not (
-            signature.return_annotation is signature.empty
-            or signature.return_annotation in [None, "None"]
-        ):
-            actual_parameters.append(FunctionDefinition.PARAM_RETURN)
+        if include_return:
+            return_annotation = signature.return_annotation
+            if not (
+                return_annotation is signature.empty
+                or return_annotation is None
+                or return_annotation is NoneType
+            ):
+                actual_parameters.append(FunctionDefinition.PARAM_RETURN)
 
         return actual_parameters
 


### PR DESCRIPTION
Class `AllTracker` parses type hints encoded as string literals to replace them with the actual type expressions. So far this was accomplished with a custom function. This PR replaces the custom function with a call to `typing.get_type_hints` for increased forward compatibility, and to support an edge case that the custom code could not handle.

A bug in the custom code breaks BCG-Gamma/sklearndf#213; this PR resolves it by using `get_type_hints()` instead.