### PR TITLE
FIX: remove .ipynb suffix from conf_base.py so nbsphinx can claim it

### DIFF
--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -138,7 +138,10 @@ intersphinx_collapsible_submodules = {
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-source_suffix = [".rst", ".md", ".ipynb"]
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
As of version 0.8.7, *nbsphinx* does not register itself for processing `.ipynb` files if the `.ipynb` suffix has already been registered.

Hence, `conf_base.py` must not register the `.ipynb` suffix or *nbsphinx* will not be triggered.

This PR removes the `.ipynb` registration from `conf_base.py`.