### PR TITLE
BUILD: update pipeline to support stricter checks in pip 20.3

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,13 @@ Release Notes
 *pytools* 2 features enhanced visualisations together with additional API improvements,
 and is now subject to static type checking with :mod:`mypy`.
 
+2.0.1
+~~~~~
+
+- BUILD: update build scripts to support the stricter dependency resolver introduced by
+  *pip 20.3*
+
+
 2.0.0
 ~~~~~
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -233,7 +233,7 @@ stages:
         - script: dir $(Build.SourcesDirectory)
 
         - script: |
-            conda install -y -c anaconda conda-build~=3.21 conda-verify toml~=0.10 flit~=3.7 packaging~=20
+            conda install -y -c anaconda "conda-build~=3.21" conda-verify "toml~=0.10" "flit~=3.7" "packaging~=20"
           displayName: 'Install conda-build, flit, toml'
           condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -233,15 +233,15 @@ stages:
         - script: dir $(Build.SourcesDirectory)
 
         - script: |
-            conda install -y -c anaconda conda-build~=3.21 conda-verify toml=0.10.* flit=3.0.* packaging~=20.9
+            conda install -y -c anaconda conda-build~=3.21 conda-verify toml~=0.10 flit~=3.7 packaging~=20
           displayName: 'Install conda-build, flit, toml'
           condition: eq(variables['BUILD_SYSTEM'], 'conda')
 
         - script: |
-            python -m pip install "toml==0.10.*"
-            python -m pip install "flit==3.0.*"
+            python -m pip install "toml~=0.10"
+            python -m pip install "flit~=3.7"
             flit --version
-            python -m pip install "tox==3.20.*"
+            python -m pip install "tox~=3.20"
             tox --version
           displayName: 'Install tox, flit & toml'
           condition: eq(variables['BUILD_SYSTEM'], 'tox')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -233,7 +233,7 @@ stages:
         - script: dir $(Build.SourcesDirectory)
 
         - script: |
-            conda install -y -c anaconda conda-build~=3.21 conda-verify~=3.4 toml~=0.10 flit~=3.7 packaging~=20.9
+            conda install -y -c anaconda conda-build~=3.21 conda-verify~=3.4 toml~=0.10 flit~=3.6 packaging~=20.9
           displayName: 'Install conda-build, flit, toml'
           condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -233,7 +233,7 @@ stages:
         - script: dir $(Build.SourcesDirectory)
 
         - script: |
-            conda install -y -c anaconda "conda-build~=3.21" conda-verify "toml~=0.10" "flit~=3.7" "packaging~=20"
+            conda install -y -c anaconda conda-build~=3.21 conda-verify~=3.4 toml~=0.10 flit~=3.7 packaging~=20.9
           displayName: 'Install conda-build, flit, toml'
           condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -241,7 +241,7 @@ stages:
             python -m pip install "toml~=0.10"
             python -m pip install "flit~=3.7"
             flit --version
-            python -m pip install "tox~=3.20"
+            python -m pip install "tox~=3.25"
             tox --version
           displayName: 'Install tox, flit & toml'
           condition: eq(variables['BUILD_SYSTEM'], 'tox')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -320,7 +320,7 @@ stages:
         - script: dir $(Build.SourcesDirectory)
 
         - script: |
-            conda install -y -c anaconda conda-build~=3.21 conda-verify toml=0.10.* flit=3.0.* packaging~=20.9
+            conda install -y -c anaconda conda-build~=3.21 conda-verify~=3.4 toml~=0.10 flit~=3.6 packaging~=20.9
           displayName: 'Install conda-build, flit, toml'
           condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ docs = [
 Documentation = "https://bcg-gamma.github.io/pytools/"
 Repository = "https://github.com/BCG-Gamma/pytools"
 
+[build]
+# comma-separated list of packages to be built from source in pip min builds
+no-binary.min = ["matplotlib"]
+
 [build.matrix.min]
 # minimum requirements of gamma-pytools
 joblib         = "~=0.14.0"
@@ -75,6 +79,7 @@ scipy          = "~=1.2.1"
 typing_inspect = "~=0.4.0"
 
 [build.matrix.max]
+# maximum requirements of gamma-pytools
 joblib         = "~=1.1"
 matplotlib     = "~=3.5"
 numpy          = ">=1.22,<2a"  # cannot use ~= due to conda bug

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,9 @@ setenv =
 # binary API.
 # This is necessary to prevent the notorious "RuntimeError: module compiled against API
 # version 0x… but this version of numpy is 0x…" error.
+# todo: remove use of legacy resolver as soon as matplotlib supports builds with the new resolver
 install_command =
-    python -m pip install {opts} {packages} --no-binary matplotlib
+    python -m pip install {opts} {packages} --no-binary matplotlib --use-deprecated legacy-resolver
 
 extras =
     testing

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ setenv =
 # version 0x… but this version of numpy is 0x…" error.
 # todo: remove use of legacy resolver as soon as matplotlib supports builds with the new resolver
 install_command =
-    python -m pip install {opts} {packages} --no-binary matplotlib --use-deprecated legacy-resolver
+    python -m pip install {opts} {packages} --no-binary '{env:FACET_NO_BINARY}'
 
 extras =
     testing


### PR DESCRIPTION
Building `matplotlib` from source fails with pip 20.3 due to stricter rules in its new dependency resolver.

We remedy this by forcing pip to use its legacy dependency resolver from previous versions of pip.