### PR TITLE
DOC: publish docs only for latest patch of each minor version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,5 +404,6 @@ TSWLatexianTemp*
 #
 # project specific
 #
+/docs
 /tmp
 !/tmp/README.md

--- a/.idea/pytools.iml
+++ b/.idea/pytools.iml
@@ -13,6 +13,7 @@
       <excludeFolder url="file://$MODULE_DIR$/sphinx/source/_generated" />
       <excludeFolder url="file://$MODULE_DIR$/sphinx/source/apidoc" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/docs" />
     </content>
     <orderEntry type="jdk" jdkName="facet-develop" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -15,6 +15,11 @@ and is now subject to static type checking with :mod:`mypy`.
 - BUILD: update build scripts to support the stricter dependency resolver introduced by
   *pip 20.3*, and to fix a compatibility issue with recent updates to nbsphinx
 - BUILD: enable local sphinx builds in other FACET packages
+- DOC: simplify how the docs build manages existing documentation of previous versions
+  in the Azure pipeline and the associated commands in `make.py`:
+  under the new approach, documentation is only preserved for the latest patch of each
+  minor version, reducing the amount of near-similar documentation
+- DOC: use pydata sphinx theme v0.9 (but disable dark mode)
 
 
 2.0.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,14 @@ stages:
               set -eux
               eval "$(conda shell.bash hook)"
               conda env create
+              conda activate $(project_name)-develop
+
+              echo "##vso[task.setvariable variable=conda_env_path]$CONDA_PREFIX"
+
           displayName: 'create development environment'
+
+        - publish: $(conda_env_path)
+          artifact: conda_environment
 
 
   - stage:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,46 +124,9 @@ stages:
                 set +x
                 echo "##vso[task.setvariable variable=conda_build_config_changed;isOutput=true]$build_changed"
 
-  - stage: create_develop_environment
-    displayName: 'Development environment'
-
-    jobs:
-    - job:
-      displayName: 'create development environment'
-
-      pool:
-          vmImage: 'ubuntu-latest'
-
-      steps:
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '3.8'
-          displayName: 'use Python 3.8'
-
-        - checkout: self
-
-        - script: dir $(Build.SourcesDirectory)
-
-        - task: Bash@3
-          inputs:
-            targetType: 'inline'
-            script: |
-              set -eux
-              eval "$(conda shell.bash hook)"
-              conda env create
-              conda activate $(project_name)-develop
-
-              echo "##vso[task.setvariable variable=conda_env_path]$CONDA_PREFIX"
-
-          displayName: 'create development environment'
-
-        - publish: $(conda_env_path)
-          artifact: conda_environment
-
-
   - stage:
     displayName: 'Unit tests'
-    dependsOn: ['detect_build_config_changes', 'create_develop_environment']
+    dependsOn: 'detect_build_config_changes'
     variables:
       conda_build_config_changed: $[ stageDependencies.detect_build_config_changes.checkout_and_diff.outputs['diff.conda_build_config_changed'] ]
 
@@ -191,9 +154,13 @@ stages:
             script: |
               set -eux
               eval "$(conda shell.bash hook)"
+
+              conda env create
+              conda activate $(project_name)-develop
+
               export PYTHONPATH=$(System.DefaultWorkingDirectory)/src/
               export RUN_PACKAGE_VERSION_TEST=$(project_name)
-              conda activate $(project_name)-develop
+
               pytest \
                  --cov $(project_name) \
                  --cov-config "tox.ini" \
@@ -614,7 +581,6 @@ stages:
   # render docs and publish to GitHub Pages
   - stage:
     displayName: 'Docs'
-    dependsOn: 'create_develop_environment'
 
     variables:
     - group: github_ssh
@@ -682,12 +648,11 @@ stages:
               echo "Checking out $(branchName)"
               git checkout $(branchName)
 
-              git status
-
-              export PYTHONPATH=$(System.DefaultWorkingDirectory)/$(project_root)/src/
+              conda env create
               conda activate $(project_name)-develop
 
-              cd $(System.DefaultWorkingDirectory)/$(project_root)/
+              export PYTHONPATH=$(System.DefaultWorkingDirectory)/$(project_root)/src/
+
               python sphinx/make.py html
 
           displayName: 'Build latest documentation'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -684,9 +684,19 @@ stages:
               mv docs $(Build.ArtifactStagingDirectory)/docs.new
           displayName: 'Merge previous and latest docs'
 
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: $(Build.ArtifactStagingDirectory)/docs.new
+            includeRootFolder: false
+            archiveType: 'zip' # Options: zip, 7z, tar, wim
+            archiveFile: $(Build.ArtifactStagingDirectory)/docs.zip
+            replaceExistingArchive: true
+            verbose: false
+            quiet: false
+
         - task: PublishBuildArtifacts@1
           inputs:
-            pathtoPublish: $(Build.ArtifactStagingDirectory)/docs.new
+            pathtoPublish: $(Build.ArtifactStagingDirectory)/docs.zip
             artifactName: $(project_name)_docs
             publishLocation: Container
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -684,6 +684,14 @@ stages:
               mv docs $(Build.ArtifactStagingDirectory)/docs.new
           displayName: 'Merge previous and latest docs'
 
+        - task: PublishBuildArtifacts@1
+          inputs:
+            pathtoPublish: $(Build.ArtifactStagingDirectory)/docs.new
+            artifactName: $(project_name)_docs
+            publishLocation: Container
+
+          displayName: 'Publish docs artifact'
+
         - task: Bash@3
           condition: eq(variables['source_is_release_branch'], 'True')
           inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,10 +124,39 @@ stages:
                 set +x
                 echo "##vso[task.setvariable variable=conda_build_config_changed;isOutput=true]$build_changed"
 
+  - stage: create_develop_environment
+    displayName: 'Development environment'
+
+    jobs:
+    - job:
+      displayName: 'create development environment'
+
+      pool:
+          vmImage: 'ubuntu-latest'
+
+      steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.8'
+          displayName: 'use Python 3.8'
+
+        - checkout: self
+
+        - script: dir $(Build.SourcesDirectory)
+
+        - task: Bash@3
+          inputs:
+            targetType: 'inline'
+            script: |
+              set -eux
+              eval "$(conda shell.bash hook)"
+              conda env create
+          displayName: 'create development environment'
+
 
   - stage:
     displayName: 'Unit tests'
-    dependsOn: 'detect_build_config_changes'
+    dependsOn: ['detect_build_config_changes', 'create_develop_environment']
     variables:
       conda_build_config_changed: $[ stageDependencies.detect_build_config_changes.checkout_and_diff.outputs['diff.conda_build_config_changed'] ]
 
@@ -157,7 +186,6 @@ stages:
               eval "$(conda shell.bash hook)"
               export PYTHONPATH=$(System.DefaultWorkingDirectory)/src/
               export RUN_PACKAGE_VERSION_TEST=$(project_name)
-              conda env create
               conda activate $(project_name)-develop
               pytest \
                  --cov $(project_name) \
@@ -579,6 +607,7 @@ stages:
   # render docs and publish to GitHub Pages
   - stage:
     displayName: 'Docs'
+    dependsOn: 'create_develop_environment'
 
     variables:
     - group: github_ssh
@@ -619,15 +648,21 @@ stages:
             targetType: 'inline'
             script: |
               set -eux
+
               cd $(System.DefaultWorkingDirectory)/$(project_root)
+              echo "Checking out github-pages"
               git checkout --track origin/github-pages
-              mkdir -p docs
-              sudo apt-get install tree
-              echo "Current docs contents:"
-              tree docs
-              mkdir $(Build.ArtifactStagingDirectory)/old_docs
-              cp -r docs $(Build.ArtifactStagingDirectory)/old_docs
-          displayName: 'Save current docs version'
+
+              # make sure we have a docs directory
+              mkdir -p docs/docs-version
+
+              echo "Current documentation contents:"
+              ls docs/docs-version
+
+              # copy the current documentation versions to the staging area
+              cp -r docs/docs-version $(Build.ArtifactStagingDirectory)/docs-version.bak
+
+          displayName: 'Retrieve current documentation versions from github-pages'
 
         - task: Bash@3
           inputs:
@@ -635,18 +670,20 @@ stages:
             script: |
               set -eux
               eval "$(conda shell.bash hook)"
+
               cd $(System.DefaultWorkingDirectory)/$(project_root)
               echo "Checking out $(branchName)"
               git checkout $(branchName)
+
               git status
+
               export PYTHONPATH=$(System.DefaultWorkingDirectory)/$(project_root)/src/
-              conda env create -f environment.yml
               conda activate $(project_name)-develop
+
               cd $(System.DefaultWorkingDirectory)/$(project_root)/
               python sphinx/make.py html
-              echo "Current docs contents:"
-              tree docs
-          displayName: 'Build new docs version'
+
+          displayName: 'Build latest documentation'
 
         - task: Bash@3
           inputs:
@@ -654,20 +691,26 @@ stages:
             script: |
               set -eux
               eval "$(conda shell.bash hook)"
-              cp -r $(Build.ArtifactStagingDirectory)/old_docs/docs .
-              echo "Current docs contents:"
-              tree docs
-              mkdir -p $(System.DefaultWorkingDirectory)/$(project_root)/sphinx/build/
-              cp -R docs/docs-version $(System.DefaultWorkingDirectory)/$(project_root)/sphinx/build/
-              echo "Building sphinx docs"
-              conda activate $(project_name)-develop
+
+              # install the tree utility
+              sudo apt-get install tree
+
               cd $(System.DefaultWorkingDirectory)/$(project_root)
+
+              echo "Restoring previous documentation to the docs directory"
+              mkdir -p docs
+              mv $(Build.ArtifactStagingDirectory)/docs-version.bak docs/docs-version
+              ls docs/docs-version
+
+              mkdir -p $(System.DefaultWorkingDirectory)/$(project_root)/sphinx/build/
+
+              conda activate $(project_name)-develop
               python sphinx/make.py prepare_docs_deployment
+
               echo "Current docs contents:"
               tree docs
-              mkdir $(Build.ArtifactStagingDirectory)/new_docs
-              mv docs $(Build.ArtifactStagingDirectory)/new_docs
-          displayName: 'Update saved docs'
+              mv docs $(Build.ArtifactStagingDirectory)/docs.new
+          displayName: 'Merge previous and latest docs'
 
         - task: Bash@3
           condition: eq(variables['source_is_release_branch'], 'True')
@@ -676,17 +719,19 @@ stages:
             script: |
               set -eux
               cd $(System.DefaultWorkingDirectory)/$(project_root)
+
               echo "Adjusting git credentials"
               git config --global user.name "Azure Pipelines"
               git config --global user.email "azuredevops@microsoft.com"
               git config --global url.ssh://git@github.com/.insteadOf https://github.com/
               git checkout github-pages
-              cp -r $(Build.ArtifactStagingDirectory)/new_docs/docs .
-              git status
+
+              mv $(Build.ArtifactStagingDirectory)/docs.new docs
               git add docs
-              echo "Staged docs HTML build"
+
               git status
               git commit -m "Publish GitHub Pages [skip ci]"
-              echo "Committed to local branch github-pages"
+
               git push --set-upstream origin github-pages
-          displayName: 'Publish docs'
+
+          displayName: 'Publish docs to branch github-pages'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -590,10 +590,10 @@ stages:
       displayName: 'Build and publish docs'
       condition: >
         or(
-        eq(variables.source_is_release_branch, 'True'),
-        eq(variables.source_is_develop_branch, 'True')
+          eq(variables.source_is_release_branch, 'True'),
+          eq(variables.source_is_develop_branch, 'True'),
+          eq(variables['Build.Reason'], 'Manual')
         )
-
 
       pool:
           vmImage: 'ubuntu-latest'

--- a/environment.yml
+++ b/environment.yml
@@ -28,14 +28,14 @@ dependencies:
   - pytest ~= 5.4
   - pytest-cov ~= 2.12
   - pyyaml ~= 5.4
-  - sphinx ~= 4.4
-  - sphinx-autodoc-typehints ~= 1.12
   - toml ~= 0.10
   - tox ~= 3.24
   - yaml ~= 0.2
+  # sphinx
+  - sphinx ~= 4.5
+  - sphinx-autodoc-typehints ~= 1.12
+  - nbsphinx ~= 0.8.9
   # notebooks
   - jupyterlab ~= 3.2
-  - nbclassic ~= 0.3
-  - nbsphinx ~= 0.8.8
   - openpyxl ~= 3.0
   - seaborn ~= 0.11

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,6 @@ dependencies:
   - mypy ~= 0.931
   - pluggy ~= 0.13
   - pre-commit ~= 2.17
-  - pydata-sphinx-theme ~= 0.7
   - pytest ~= 5.4
   - pytest-cov ~= 2.12
   - pyyaml ~= 5.4
@@ -35,6 +34,7 @@ dependencies:
   - sphinx ~= 4.5
   - sphinx-autodoc-typehints ~= 1.12
   - nbsphinx ~= 0.8.9
+  - pydata-sphinx-theme ~= 0.9
   # notebooks
   - jupyterlab ~= 3.2
   - openpyxl ~= 3.0

--- a/sphinx/base/_static/js/gamma.js
+++ b/sphinx/base/_static/js/gamma.js
@@ -7,7 +7,8 @@ $(document).ready(function() {
 
 const buildVersionSelector = function() {
 
-    const versionSelector = $('<select/>');
+    const versionDropdown = $('<div class="navbar-end-item"><select/></div>');
+    const versionSelector = versionDropdown.children()
 
     versionSelector.change(function() {
         navigateToDocsVersion($(this).val());
@@ -15,16 +16,16 @@ const buildVersionSelector = function() {
 
     const activeDocsVersion = getActiveDocsVersion()
 
-    DOCS_VERSIONS.non_rc.forEach(function(docsVersion) {
+    DOCS_VERSIONS.all.forEach(function(docsVersion) {
         versionSelector
             .append($('<option/>')
                 .html("Version: " + docsVersion)
                 .attr("value", docsVersion)
-                .attr("selected", docsVersion === activeDocsVersion)
+                .attr("selected", docsVersion.startsWith(activeDocsVersion))
             );
     });
 
-    $("#navbar-menu").append(versionSelector);
+    $("#navbar-end").append(versionDropdown);
 }
 
 const getActiveDocsVersion = function() {
@@ -32,7 +33,7 @@ const getActiveDocsVersion = function() {
     if (currentLocation.indexOf("docs-version") === -1) {
         return DOCS_VERSIONS.current;
     } else {
-        const rExp = /.*docs-version\/(\d-\d-\d.*)\/.*/g;
+        const rExp = /.*docs-version\/(\d-\d.*)\/.*/g;
         const matches = rExp.exec(currentLocation);
         if (matches && matches.length > 1) {
             // convert back from URL to real version string
@@ -45,15 +46,12 @@ const getActiveDocsVersion = function() {
 
 const navigateToDocsVersion = function(targetVersion) {
     const currentLocation = window.location + "";
-    let newLocation = currentLocation;
+    const subUrl = "docs-version/" + targetVersion.split(".").slice(0, 2).join("-") + "/index.html";
 
-    const subUrl = "docs-version/" + targetVersion.split(".").join("-") + "/index.html";
     if (currentLocation.indexOf("docs-version/") > 0) {
         const startIndex = currentLocation.indexOf("docs-version/")
-        newLocation = currentLocation.substring(0, startIndex) + subUrl
+        window.location = currentLocation.substring(0, startIndex) + subUrl
     } else {
-        newLocation = subUrl
+        window.location = subUrl
     }
-
-    window.location = newLocation;
 }

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -168,7 +168,11 @@ html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
     "navigation_depth": 4,
+    # Omit the `theme-switcher` since we don't support dark mode:
+    "navbar_end": ["navbar-icon-links"],
 }
+
+html_context = {"default_mode": "light"}
 
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/sphinx/base/make_base.py
+++ b/sphinx/base/make_base.py
@@ -328,7 +328,7 @@ class PrepareDocsDeployment(Command):
         if os.path.exists(DIR_ALL_DOCS_VERSIONS) and os.path.isdir(
             DIR_ALL_DOCS_VERSIONS
         ):
-            log(str(os.listdir(DIR_ALL_DOCS_VERSIONS)))
+            log(os.listdir(DIR_ALL_DOCS_VERSIONS))
 
         else:
             raise FileNotFoundError(
@@ -508,13 +508,13 @@ def make() -> None:
         executed_commands.add(next_command)
 
 
-def log(message: str) -> None:
+def log(message: Any) -> None:
     """
     Write a message to `stderr`.
 
     :param message: the message to write
     """
-    print(message, file=sys.stderr)
+    print(str(message), file=sys.stderr)
 
 
 def quote_path(path: str) -> str:

--- a/sphinx/base/make_base.py
+++ b/sphinx/base/make_base.py
@@ -266,7 +266,7 @@ class FetchPkgVersions(Command):
         with open(FILE_JS_VERSIONS, "wt") as f:
             f.write(version_data_as_js)
 
-        log(f"Version data written into: {FILE_JS_VERSIONS}")
+        log(f"Version data written to: {FILE_JS_VERSIONS}")
 
 
 class PrepareDocsDeployment(Command):

--- a/sphinx/base/make_base.py
+++ b/sphinx/base/make_base.py
@@ -11,15 +11,18 @@ import shutil
 import subprocess
 import sys
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 from glob import glob
-from tempfile import TemporaryDirectory
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 from weakref import ref
 
 from make_util import get_package_version as _get_package_version
 from packaging import version as pkg_version
 
-DIR_SPHINX_ROOT = os.getcwd()
+DIR_SPHINX_ROOT = os.path.dirname(os.path.dirname(__file__))
+assert (
+    os.path.basename(DIR_SPHINX_ROOT) == "sphinx"
+), f"Sphinx root dir {DIR_SPHINX_ROOT!r} is named 'sphinx'"
 
 # Sphinx commands
 CMD_SPHINX_BUILD = "sphinx-build"
@@ -27,20 +30,21 @@ CMD_SPHINX_AUTOGEN = "sphinx-autogen"
 
 # File paths
 DIR_SPHINX_BASE = os.path.dirname(os.path.realpath(__file__))
-DIR_REPO_ROOT = os.path.realpath(os.path.join(DIR_SPHINX_ROOT, os.pardir))
-DIR_REPO_PARENT = os.path.realpath(os.path.join(DIR_REPO_ROOT, os.pardir))
+DIR_REPO_ROOT = os.path.dirname(DIR_SPHINX_ROOT)
+DIR_REPO_PARENT = os.path.dirname(DIR_REPO_ROOT)
 PROJECT_NAME = os.path.split(os.path.realpath(DIR_REPO_ROOT))[1]
 DIR_PACKAGE_SRC = os.path.join(DIR_REPO_ROOT, "src")
 DIR_DOCS = os.path.join(DIR_REPO_ROOT, "docs")
+DIR_DOCS_VERSION = os.path.join(DIR_DOCS, "docs-version")
 DIR_SPHINX_SOURCE = os.path.join(DIR_SPHINX_ROOT, "source")
 DIR_SPHINX_AUX = os.path.join(DIR_SPHINX_ROOT, "auxiliary")
 DIR_SPHINX_API_GENERATED = os.path.join(DIR_SPHINX_SOURCE, "apidoc")
 DIR_SPHINX_GENERATED = os.path.join(DIR_SPHINX_SOURCE, "_generated")
 DIR_SPHINX_BUILD = os.path.join(DIR_SPHINX_ROOT, "build")
+DIR_SPHINX_BUILD_DOCS_VERSION = os.path.join(DIR_SPHINX_BUILD, "docs-version")
 DIR_SPHINX_BUILD_HTML = os.path.join(DIR_SPHINX_BUILD, "html")
 DIR_SPHINX_TEMPLATES = os.path.join(DIR_SPHINX_ROOT, "base", "_templates")
 DIR_SPHINX_TUTORIAL = os.path.join(DIR_SPHINX_SOURCE, "tutorial")
-DIR_ALL_DOCS_VERSIONS = os.path.join(DIR_SPHINX_BUILD, "docs-version")
 DIR_PACKAGE_ROOT = os.path.abspath(os.path.join(DIR_REPO_ROOT, "src", PROJECT_NAME))
 
 FILE_AUTOSUMMARY_TEMPLATE = os.path.join(DIR_SPHINX_GENERATED, "autosummary.rst_")
@@ -90,6 +94,9 @@ class Command(metaclass=CommandMeta):
     def __init__(self) -> None:
         self.name = self.__RE_CAMEL_TO_SNAKE.sub("_", type(self).__name__).lower()
 
+        # get the current version of the package we're building documentation for
+        self.package_version: pkg_version.Version = get_package_version()
+
     @abstractmethod
     def get_description(self) -> str:
         pass
@@ -117,7 +124,7 @@ class Command(metaclass=CommandMeta):
         return dependencies_extended
 
     def run(self) -> None:
-        log(f"Running command {self.name} – {self.get_description()}")
+        log(f"{'=' * 80}\n" f"Running command {self.name} – {self.get_description()}\n")
         self._run()
 
     @abstractmethod
@@ -244,11 +251,10 @@ class FetchPkgVersions(Command):
         return ()
 
     def _run(self) -> None:
-        versions = Versions()
+        versions = get_versions()
 
         version_data = {
-            "current": str(versions.latest_stable_version),
-            "non_rc": list(map(str, versions.version_tags_stable)),
+            "current": str(versions.latest_version),
             "all": list(map(str, versions.version_tags)),
         }
 
@@ -264,117 +270,80 @@ class FetchPkgVersions(Command):
 
 class PrepareDocsDeployment(Command):
     def get_description(self) -> str:
-        return "update versions of rendered documentation"
+        return "integrate documentation of previous versions"
 
     def get_dependencies(self) -> Tuple[Command, ...]:
         return ()
 
     def _run(self) -> None:
+        # we expect to find all previous documentation in docs/
+        # and the newly built documentation in sphinx/build/
         if not is_azure_build():
             raise RuntimeError("only implemented for Azure Pipelines")
 
-        # get the current version of the package
-        current_version: pkg_version.Version = get_package_version()
-
-        # copy new the docs version to the deployment path
-        if current_version == Versions().latest_stable_version:
-            self._copy_latest_docs()
-        else:
-            self._update_versions_js()
-
-        self._copy_historic_docs(current_version)
+        # copy the new docs version to the deployment path
+        self._copy_new_documentation()
 
         self._update_historic_docs()
 
-    @staticmethod
-    def _copy_latest_docs() -> None:
-        # only copy to deployment path if our version is the latest stable release
-        log("Build is latest stable release – updating root docs.")
+        self._copy_latest_to_docs_root()
 
-        # remove docs build currently deployed, except for the docs versions folder
-        if os.path.exists(os.path.join(DIR_DOCS, "docs-version")):
-            with TemporaryDirectory() as DIR_TMP:
-                shutil.move(src=os.path.join(DIR_DOCS, "docs-version"), dst=DIR_TMP)
-                shutil.rmtree(path=DIR_DOCS)
-                os.makedirs(DIR_DOCS)
-                shutil.move(src=os.path.join(DIR_TMP, "docs-version"), dst=DIR_DOCS)
-        else:
-            os.makedirs(DIR_DOCS, exist_ok=True)
+        self._tidy_up_docs_root()
+
+    def _copy_new_documentation(self) -> None:
+        log("Adding new documentation to documentation version history")
+
+        os.makedirs(DIR_DOCS_VERSION, exist_ok=True)
+
+        dir_docs_current_version = os.path.join(
+            DIR_DOCS_VERSION,
+            version_string_to_url(self.package_version),
+        )
+
+        if os.path.exists(dir_docs_current_version):
+            # remove a previous version of the same documentation if it exists
+            shutil.rmtree(dir_docs_current_version)
 
         # copy new docs version to deployment path
-        shutil.copytree(src=DIR_SPHINX_BUILD_HTML, dst=DIR_DOCS, dirs_exist_ok=True)
+        shutil.copytree(src=DIR_SPHINX_BUILD_HTML, dst=dir_docs_current_version)
 
-    @staticmethod
-    def _update_versions_js() -> None:
-        # build of a pre-release or patch to an earlier release
-        log("Build is not latest stable release – just updating versions.")
-        # – only update "versions.js":
-        new_versions_js = os.path.join(DIR_SPHINX_BUILD_HTML, FILE_JS_VERSIONS_RELATIVE)
-        if not os.path.exists(new_versions_js):
-            raise FileNotFoundError(f"No versions.js file at: {new_versions_js}")
-
-        versions_js_out = os.path.join(DIR_DOCS, FILE_JS_VERSIONS_RELATIVE)
-
-        os.makedirs(os.path.dirname(versions_js_out), exist_ok=True)
-
-        log(
-            "Copying updated versions.js file from "
-            f"'{new_versions_js}' to '{versions_js_out}'"
-        )
-
-        shutil.copy(src=new_versions_js, dst=versions_js_out)
-
-    @staticmethod
-    def _copy_historic_docs(current_version: pkg_version.Version) -> None:
-        # get current version of package in the form of folder/URL name (e.g., "1-0-0")
-        current_version_path = os.path.join(
-            DIR_DOCS, "docs-version", version_string_to_url(current_version)
-        )
-        # update latest version in docs history
-        if os.path.exists(current_version_path):
-            shutil.rmtree(path=current_version_path)
-
-        log(f"Copying pre-existing docs from: '{DIR_ALL_DOCS_VERSIONS}'")
-
-        if os.path.exists(DIR_ALL_DOCS_VERSIONS) and os.path.isdir(
-            DIR_ALL_DOCS_VERSIONS
-        ):
-            log("Pre-existing docs contents:")
-            log(os.listdir(DIR_ALL_DOCS_VERSIONS))
-
-        else:
-            raise FileNotFoundError(
-                f"'{DIR_ALL_DOCS_VERSIONS}' is missing or not a dir"
-            )
-
-        shutil.copytree(
-            src=DIR_ALL_DOCS_VERSIONS,
-            dst=os.path.join(DIR_DOCS, "docs-version"),
-            dirs_exist_ok=True,
-        )
-
-    @staticmethod
-    def _update_historic_docs() -> None:
+    def _update_historic_docs(self) -> None:
         # Replace all docs version lists with the most up-to-date to have all versions
         # accessible also from older versions
-        new_versions_js = os.path.join(DIR_DOCS, FILE_JS_VERSIONS_RELATIVE)
-        for d in glob(os.path.join(DIR_DOCS, "docs-version", "*", "")):
-            old_versions_js = os.path.join(d, FILE_JS_VERSIONS_RELATIVE)
-            log(
-                "Copying versions.js file from "
-                f"'{new_versions_js}' to '{old_versions_js}'"
-            )
-            shutil.copyfile(src=new_versions_js, dst=old_versions_js)
+        new_versions_js = os.path.join(
+            DIR_DOCS_VERSION,
+            version_string_to_url(self.package_version),
+            FILE_JS_VERSIONS_RELATIVE,
+        )
 
+        for d in glob(os.path.join(DIR_DOCS_VERSION, "*")):
+            old_versions_js = os.path.join(d, FILE_JS_VERSIONS_RELATIVE)
+            if old_versions_js != new_versions_js:
+                log(
+                    "Copying versions.js file from "
+                    f"'{new_versions_js}' to '{old_versions_js}'"
+                )
+                shutil.copyfile(src=new_versions_js, dst=old_versions_js)
+
+    @staticmethod
+    def _copy_latest_to_docs_root() -> None:
+        # copy latest version to root
+
+        dir_latest_version = os.path.join(
+            DIR_DOCS_VERSION, version_string_to_url(get_versions().latest_version)
+        )
+        shutil.copytree(src=dir_latest_version, dst=DIR_DOCS, dirs_exist_ok=True)
+
+    @staticmethod
+    def _tidy_up_docs_root() -> None:
         # remove .buildinfo which interferes with GitHub Pages build
-        if os.path.exists(os.path.join(DIR_DOCS, ".buildinfo")):
-            os.remove(os.path.join(DIR_DOCS, ".buildinfo"))
+        file_build_info = os.path.join(DIR_DOCS, ".buildinfo")
+        if os.path.exists(file_build_info):
+            os.remove(file_build_info)
 
         # create empty file to signal that no GitHub auto-rendering is required
         # noinspection SpellCheckingInspection
         open(os.path.join(DIR_DOCS, ".nojekyll"), "a").close()
-
-        log("Docs moved to ./docs and historic versions updated")
 
 
 class Html(Command):
@@ -402,31 +371,6 @@ class Html(Command):
             check=True,
         )
 
-        # create interactive versions of all notebooks
-        sys.path.append(DIR_SPHINX_BASE)
-
-        # create copy of this build for the docs archive
-        version_built: pkg_version.Version = get_package_version()
-        dir_path_this_build = os.path.join(
-            DIR_ALL_DOCS_VERSIONS, version_string_to_url(version_built)
-        )
-
-        os.makedirs(DIR_ALL_DOCS_VERSIONS, exist_ok=True)
-        if os.path.exists(dir_path_this_build):
-            shutil.rmtree(dir_path_this_build)
-
-        shutil.copytree(
-            src=DIR_SPHINX_BUILD_HTML,
-            dst=dir_path_this_build,
-        )
-
-        if not is_azure_build():
-            shutil.move(src=DIR_ALL_DOCS_VERSIONS, dst=DIR_SPHINX_BUILD_HTML)
-
-        # empty versions file to blank template
-        with open(FILE_JS_VERSIONS, "wt") as f:
-            f.write("")
-
 
 class Help(Command):
     def get_description(self) -> str:
@@ -444,43 +388,59 @@ class Versions:
     Helper class that lists all versions that have already been released.
     """
 
-    INITIAL_VERSION_TAG = pkg_version.parse("1.0.1")
+    def __init__(self, version_tags: Iterable[pkg_version.Version]) -> None:
+        self.version_tags = sorted(version_tags, reverse=True)
 
-    def __init__(self) -> None:
-        os.makedirs(DIR_SPHINX_BUILD, exist_ok=True)
-        start_from_version_tag: pkg_version.Version = Versions.INITIAL_VERSION_TAG
-        sp = subprocess.run(
-            args='git tag -l "*.*.*"', shell=True, check=True, stdout=subprocess.PIPE
-        )
-        version_tags: List[pkg_version.Version] = [
-            version_tag
-            for version_tag in (
-                pkg_version.parse(version_string)
-                for version_string in sp.stdout.decode("UTF-8").split("\n")
-                if version_string
+    @property
+    def latest_version(self) -> pkg_version:
+        return self.version_tags[0]
+
+
+_versions: Optional[Versions] = None
+
+
+def get_versions() -> Versions:
+    global _versions
+
+    if _versions is not None:
+        return _versions
+
+    os.makedirs(DIR_SPHINX_BUILD, exist_ok=True)
+    start_from_version_tag: pkg_version.Version = pkg_version.Version("1.0")
+
+    version_tags: Iterable[pkg_version.Version] = (
+        pkg_version.parse(s)
+        for s in (
+            subprocess.run(
+                args='git tag -l "*.*.*"',
+                shell=True,
+                check=True,
+                stdout=subprocess.PIPE,
             )
-            if version_tag >= start_from_version_tag
-        ]
+            .stdout.decode("UTF-8")
+            .split("\n")
+        )
+        if s
+    )
 
-        # append the version we are building to version_tags
-        version_built: pkg_version.Version = get_package_version()
+    # append the version we are building to version_tags
+    version_built: pkg_version.Version = get_package_version()
+    version_tags = (*version_tags, version_built)
 
-        if version_built not in version_tags:
-            version_tags.append(version_built)
+    versions_by_minor_version: Dict[str, List[pkg_version.Version]] = defaultdict(list)
 
-        version_tags.sort()
-        version_tags.reverse()
-        version_tags_stable: List[pkg_version.Version] = [
-            vt for vt in version_tags if not (vt.is_prerelease or vt.is_devrelease)
-        ]
-        latest_stable_version: pkg_version.Version = version_tags_stable[0]
+    for v in version_tags:
+        if not (v.is_prerelease or v.is_devrelease) and v >= start_from_version_tag:
+            versions_by_minor_version[f"{v.major}.{v.minor}"].append(v)
 
-        log(f"Found versions: {', '.join(map(str, version_tags))}")
-        log(f"Latest stable version: {latest_stable_version}")
+    minor_versions: List[pkg_version] = [
+        max(versions) for versions in versions_by_minor_version.values()
+    ]
 
-        self.version_tags = version_tags
-        self.version_tags_stable = version_tags_stable
-        self.latest_stable_version = latest_stable_version
+    log(f"Found minor versions: {', '.join(map(str, minor_versions))}")
+
+    _versions = Versions(minor_versions)
+    return _versions
 
 
 def make() -> None:
@@ -545,7 +505,12 @@ def is_azure_build() -> bool:
     """
     Check if this is an Azure DevOps pipelines build
     """
-    return "BUILD_REASON" in os.environ
+    is_azure = "BUILD_REASON" in os.environ
+
+    if is_azure:
+        log("Azure build detected")
+
+    return is_azure
 
 
 def get_package_version() -> pkg_version.Version:
@@ -561,7 +526,7 @@ def version_string_to_url(version: pkg_version.Version) -> str:
 
     Our convention is to only replace all dots with dashes.
     """
-    return str(version).replace(".", "-")
+    return f"{version.major}-{version.minor}"
 
 
 def check_sphinx_version() -> None:

--- a/sphinx/base/make_base.py
+++ b/sphinx/base/make_base.py
@@ -56,6 +56,10 @@ FILE_JS_VERSIONS = os.path.join(DIR_SPHINX_BASE, FILE_JS_VERSIONS_RELATIVE)
 ENV_PYTHON_PATH = "PYTHONPATH"
 
 
+# Version of the package being built
+PACKAGE_VERSION = _get_package_version(package_path=DIR_PACKAGE_ROOT)
+
+
 class CommandMeta(ABCMeta):
     """
     Meta-class for command classes.
@@ -94,9 +98,6 @@ class Command(metaclass=CommandMeta):
     def __init__(self) -> None:
         self.name = self.__RE_CAMEL_TO_SNAKE.sub("_", type(self).__name__).lower()
 
-        # get the current version of the package we're building documentation for
-        self.package_version: pkg_version.Version = get_package_version()
-
     @abstractmethod
     def get_description(self) -> str:
         pass
@@ -124,7 +125,7 @@ class Command(metaclass=CommandMeta):
         return dependencies_extended
 
     def run(self) -> None:
-        log(f"{'=' * 80}\n" f"Running command {self.name} – {self.get_description()}\n")
+        log(f"{'=' * 80}\nRunning command {self.name} – {self.get_description()}\n")
         self._run()
 
     @abstractmethod
@@ -297,7 +298,7 @@ class PrepareDocsDeployment(Command):
 
         dir_docs_current_version = os.path.join(
             DIR_DOCS_VERSION,
-            version_string_to_url(self.package_version),
+            version_string_to_url(PACKAGE_VERSION),
         )
 
         if os.path.exists(dir_docs_current_version):
@@ -312,7 +313,7 @@ class PrepareDocsDeployment(Command):
         # accessible also from older versions
         new_versions_js = os.path.join(
             DIR_DOCS_VERSION,
-            version_string_to_url(self.package_version),
+            version_string_to_url(PACKAGE_VERSION),
             FILE_JS_VERSIONS_RELATIVE,
         )
 
@@ -424,8 +425,7 @@ def get_versions() -> Versions:
     )
 
     # append the version we are building to version_tags
-    version_built: pkg_version.Version = get_package_version()
-    version_tags = (*version_tags, version_built)
+    version_tags = (*version_tags, PACKAGE_VERSION)
 
     versions_by_minor_version: Dict[str, List[pkg_version.Version]] = defaultdict(list)
 
@@ -511,13 +511,6 @@ def is_azure_build() -> bool:
         log("Azure build detected")
 
     return is_azure
-
-
-def get_package_version() -> pkg_version.Version:
-    """
-    Get the version of the package being built.
-    """
-    return _get_package_version(package_path=DIR_PACKAGE_ROOT)
 
 
 def version_string_to_url(version: pkg_version.Version) -> str:


### PR DESCRIPTION
This PR significantly simplifies how the docs build manages existing documentation of previous versions in the Azure pipeline and the associated commands in `make.py`.

Under the new approach, documentation is only preserved for the latest patch of each minor version, reducing the amount of near-similar documentation.

We also add support for v0.9 of the *pydata* sphinx theme (but disable dark mode)