### PR TITLE
API: add new Sphinx callbacks TrackCurrentClass and RenamePrivateArguments

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -15,6 +15,12 @@ Release Notes
   called after their associated object has been fitted using :meth:`.FittableMixin.fit`.
 - API: remove method ``ensure_fitted`` from :class:`.FittableMixin`, which is no longer
   needed due to the new decorator :obj:`.fitted_only`.
+- API: new Sphinx callback :class:`.TrackCurrentClass` to keep track of the current
+  class being processed by *autodoc*.
+- API: new Sphinx callback :class:`.RenamePrivateArguments` to rename private
+  “positional-only” arguments in a function's signature (with two leading underscores)
+  back to their original names in the source code, so that *autodoc* can pick them up
+  correctly.
 
 
 *pytools* 2.0

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -192,6 +192,13 @@ def setup(app: Sphinx) -> None:
     :param app: the Sphinx application object
     """
 
+    _connect_callbacks(app=app)
+
+    _add_custom_css_and_js(app=app)
+
+
+def _connect_callbacks(app: Sphinx) -> None:
+
     from pytools.sphinx.util import (
         AddInheritance,
         CollapseModulePathsInDocstring,
@@ -199,6 +206,7 @@ def setup(app: Sphinx) -> None:
         CollapseModulePathsInXRef,
         RenamePrivateArguments,
         Replace3rdPartyDoc,
+        ResolveTypeVariables,
         SkipIndirectImports,
         TrackCurrentDoc,
     )
@@ -221,13 +229,13 @@ def setup(app: Sphinx) -> None:
 
     TrackCurrentDoc().connect(app=app)
 
+    ResolveTypeVariables().connect(app=app)
+
     CollapseModulePathsInXRef(
         collapsible_submodules=intersphinx_collapsible_submodules
     ).connect(app=app)
 
     RenamePrivateArguments().connect(app=app)
-
-    _add_custom_css_and_js(app=app)
 
 
 def _add_custom_css_and_js(app: Sphinx) -> None:

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -8,7 +8,7 @@ import logging
 import os
 import shutil
 import sys
-from typing import Any, Dict, Optional, Tuple, Type, cast
+from typing import Any, Dict, Optional, Tuple
 
 from sphinx.application import Sphinx
 
@@ -192,122 +192,16 @@ def setup(app: Sphinx) -> None:
     :param app: the Sphinx application object
     """
 
-    from types import FunctionType
-
-    from pytools.meta import SingletonABCMeta
-    from pytools.sphinx import AutodocBeforeProcessSignature, AutodocProcessSignature
     from pytools.sphinx.util import (
         AddInheritance,
         CollapseModulePathsInDocstring,
         CollapseModulePathsInSignature,
         CollapseModulePathsInXRef,
+        RenamePrivateArguments,
         Replace3rdPartyDoc,
-        ResolveTypeVariables,
         SkipIndirectImports,
+        TrackCurrentDoc,
     )
-
-    # todo: move this class to package pytools.sphinx.util once we release pytools 2.1
-    class TrackCurrentDoc(
-        AutodocProcessSignature,  # type: ignore
-        metaclass=SingletonABCMeta,
-    ):
-        """
-        Keep track of the class currently being processed by autodoc.
-
-        This is required to attribute unbound methods to the correct class, e.g.,
-        in class :class:`.ResolveTypeVariables`.
-        """
-
-        def __init__(self) -> None:
-            self.current_class: Optional[Type[Any]] = None
-            self.rtv = ResolveTypeVariables()
-
-        def process(
-            self,
-            app: Sphinx,
-            what: str,
-            name: str,
-            obj: object,
-            options: object,
-            signature: Optional[str],
-            return_annotation: Optional[str],
-        ) -> Optional[Tuple[Optional[str], Optional[str]]]:
-            if what == "class":
-                cls = cast(type, obj)
-                self.current_class = cls
-                self.rtv._update_current_class(cls)
-
-            return None
-
-        def connect(self, app: Sphinx, priority: Optional[int] = None) -> int:
-            self.rtv.connect(app, priority)
-            return cast(int, super().connect(app, priority))
-
-    class RenamePrivateArguments(
-        AutodocBeforeProcessSignature,  # type: ignore
-        metaclass=SingletonABCMeta,
-    ):
-        """
-        Rename private argument names to their original names given in the source code.
-
-        For example, arg ``__x`` of method ``f`` in
-
-        .. code-block:: python
-
-            class A:
-                def f(self, __x: int) -> None:
-                    ...
-
-        will be renamed from its internal, private name ``_A__x`` back to ``__x``.
-        """
-
-        def process(self, app: Sphinx, obj: Any, bound_method: bool) -> None:
-            if not (bound_method or isinstance(obj, FunctionType)):
-                return
-
-            # get the name of the module or class that the function is a member of
-            try:
-                containers = obj.__qualname__.split(".")
-            except AttributeError:
-                return
-
-            if len(containers) < 2:
-                return
-
-            private_prefix = f"_{containers[-2]}__"
-
-            def get_public_name(name: str) -> str:
-                if name.startswith(private_prefix):
-                    return name[len(private_prefix) - 2 :]
-                else:
-                    return name
-
-            # get the original signature
-            try:
-                annotations: Dict[str, Any] = obj.__annotations__
-            except AttributeError:
-                annotations = {}
-
-            annotations_original = list(annotations.items())
-            for name, annotation in annotations_original:
-                public_name = get_public_name(name)
-                if public_name is not name:
-                    del annotations[name]
-                    annotations[public_name] = annotation
-
-            try:
-                code = obj.__code__
-                arg_and_variable_names = code.co_varnames
-                if any(
-                    name.startswith(private_prefix) for name in arg_and_variable_names
-                ):
-                    obj.__code__ = code.replace(
-                        co_varnames=tuple(
-                            get_public_name(name) for name in arg_and_variable_names
-                        ),
-                    )
-            except AttributeError:
-                pass
 
     AddInheritance(collapsible_submodules=intersphinx_collapsible_submodules).connect(
         app=app

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -208,7 +208,7 @@ def _connect_callbacks(app: Sphinx) -> None:
         Replace3rdPartyDoc,
         ResolveTypeVariables,
         SkipIndirectImports,
-        TrackCurrentDoc,
+        TrackCurrentClass,
     )
 
     AddInheritance(collapsible_submodules=intersphinx_collapsible_submodules).connect(
@@ -227,7 +227,7 @@ def _connect_callbacks(app: Sphinx) -> None:
 
     Replace3rdPartyDoc().connect(app=app)
 
-    TrackCurrentDoc().connect(app=app)
+    TrackCurrentClass().connect(app=app)
 
     ResolveTypeVariables().connect(app=app)
 

--- a/src/pytools/sphinx/util/_util.py
+++ b/src/pytools/sphinx/util/_util.py
@@ -716,7 +716,19 @@ def _class_attr(cls: Any, attr: List[str]) -> Any:
 
 
 class _TypeVarBindings:
-    def __init__(self, current_class: type) -> None:
+
+    current_class: Type[Any]
+    _bindings: Dict[
+        Type[Any],
+        Dict[
+            TypeVar,
+            Union[Type[Any], TypeVar],
+        ],
+    ]
+
+    def __init__(self, current_class: Type[Any]) -> None:
+        super().__init__()
+
         self.current_class = current_class
         self._bindings = self._get_parameter_bindings(
             cls=current_class, subclass_bindings={}
@@ -812,7 +824,9 @@ class ResolveTypeVariables(AutodocBeforeProcessSignature, metaclass=SingletonABC
 
     original_signatures: Dict[Any, Dict[str, Union[Type[Any], TypeVar]]]
 
+    _current_class: Optional[Type[Any]]
     _current_class_bindings: Optional[_TypeVarBindings]
+    _track_current_class: "TrackCurrentDoc"
 
     def __init__(self) -> None:
         self.original_signatures = {}
@@ -1036,6 +1050,9 @@ class TrackCurrentDoc(AutodocProcessSignature, metaclass=SingletonABCMeta):
     in class :class:`.ResolveTypeVariables`.
     """
 
+    #: The class currently being processed by autodoc.
+    current_class: Optional[Type[Any]]
+
     def __init__(self) -> None:
         self.current_class: Optional[Type[Any]] = None
         self.rtv = ResolveTypeVariables()
@@ -1050,6 +1067,8 @@ class TrackCurrentDoc(AutodocProcessSignature, metaclass=SingletonABCMeta):
         signature: Optional[str],
         return_annotation: Optional[str],
     ) -> Optional[Tuple[Optional[str], Optional[str]]]:
+        """[see superclass]"""
+
         if what == "class":
             cls = cast(type, obj)
             self.current_class = cls

--- a/src/pytools/sphinx/util/_util.py
+++ b/src/pytools/sphinx/util/_util.py
@@ -8,7 +8,7 @@ import logging
 import re
 import sys
 import typing
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 from inspect import getattr_static
 from types import FunctionType, MethodType
 from typing import (
@@ -316,7 +316,7 @@ class AddInheritance(AutodocProcessDocstring):
         ]
 
 
-class CollapseModulePaths(metaclass=SingletonABCMeta):
+class CollapseModulePaths(metaclass=ABCMeta):
     """
     Replace private module paths with their public prefix so that object references
     can be matched by *intersphinx*.

--- a/src/pytools/sphinx/util/_util.py
+++ b/src/pytools/sphinx/util/_util.py
@@ -103,7 +103,7 @@ __all__ = [
     "Replace3rdPartyDoc",
     "ResolveTypeVariables",
     "SkipIndirectImports",
-    "TrackCurrentDoc",
+    "TrackCurrentClass",
 ]
 
 #
@@ -828,7 +828,7 @@ class ResolveTypeVariables(AutodocBeforeProcessSignature, metaclass=SingletonABC
 
     _current_class: Optional[Type[Any]]
     _current_class_bindings: Optional[_TypeVarBindings]
-    _track_current_class: "TrackCurrentDoc"
+    _track_current_class: "TrackCurrentClass"
 
     def __init__(self) -> None:
         super().__init__()
@@ -836,14 +836,14 @@ class ResolveTypeVariables(AutodocBeforeProcessSignature, metaclass=SingletonABC
         self.original_signatures = {}
         self._current_class = None
         self._current_class_bindings = None
-        self._track_current_class = TrackCurrentDoc()
+        self._track_current_class = TrackCurrentClass()
 
     def connect(self, app: Sphinx, priority: Optional[int] = None) -> int:
         """[see superclass]"""
 
-        if TrackCurrentDoc().app is not app:
+        if TrackCurrentClass().app is not app:
             raise RuntimeError(
-                f"connect {TrackCurrentDoc.__name__}() to the same app "
+                f"connect {TrackCurrentClass.__name__}() to the same app "
                 f"before connecting {ResolveTypeVariables.__name__}()"
             )
 
@@ -1091,7 +1091,8 @@ class ResolveTypeVariables(AutodocBeforeProcessSignature, metaclass=SingletonABC
         return bindings
 
 
-class TrackCurrentDoc(AutodocProcessSignature, metaclass=SingletonABCMeta):
+@inheritdoc(match="""[see superclass]""")
+class TrackCurrentClass(AutodocProcessSignature, metaclass=SingletonABCMeta):
     """
     Keep track of the class currently being processed by autodoc.
 
@@ -1126,6 +1127,7 @@ class TrackCurrentDoc(AutodocProcessSignature, metaclass=SingletonABCMeta):
         return None
 
 
+@inheritdoc(match="""[see superclass]""")
 class RenamePrivateArguments(AutodocBeforeProcessSignature, metaclass=SingletonABCMeta):
     """
     Rename private argument names to their original names given in the source code.
@@ -1142,6 +1144,8 @@ class RenamePrivateArguments(AutodocBeforeProcessSignature, metaclass=SingletonA
     """
 
     def process(self, app: Sphinx, obj: Any, bound_method: bool) -> None:
+        """[see superclass]"""
+
         if not (bound_method or isinstance(obj, FunctionType)):
             return
 

--- a/src/pytools/sphinx/util/_util.py
+++ b/src/pytools/sphinx/util/_util.py
@@ -1026,26 +1026,25 @@ class ResolveTypeVariables(AutodocBeforeProcessSignature, metaclass=SingletonABC
             if obj.__name__ == obj.__qualname__:
                 # this is a function, not a method
                 return
-            elif obj.__name__ in [
-                "__init__",
-                "__init_subclass__",
-                "__new__",
-                "__call__",
-            ]:
+
+            defining_class = self._get_defining_class(obj)
+            assert (
+                defining_class is not None
+            ), f"function {obj.__qualname__} has a defining class"
+
+            if obj.__name__ in ["__init__", "__init_subclass__", "__new__"] or (
+                obj.__name__ == "__call__" and issubclass(defining_class, type)
+            ):
                 # special case of class initializer, this usually means that we are
                 # starting to document a new class, or refer to a special method
                 # of a metaclass
-                bindings = self._update_current_class(self._get_defining_class(obj))
+                bindings = self._update_current_class(defining_class)
             else:
                 bindings = self._current_class_bindings
 
             assert (
                 bindings is not None
             ), f"bindings are in place for function {obj.__qualname__}"
-            defining_class = self._get_defining_class(obj)
-            assert (
-                defining_class is not None
-            ), f"function {obj.__qualname__} has a defining class"
             assert issubclass(bindings.current_class, defining_class), (
                 f"current class {bindings.current_class.__name__} "
                 f"is a subclass of the class of unbound method {obj.__qualname__}, "

--- a/src/pytools/sphinx/util/_util.py
+++ b/src/pytools/sphinx/util/_util.py
@@ -8,7 +8,7 @@ import logging
 import re
 import sys
 import typing
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 from inspect import getattr_static
 from types import FunctionType, MethodType
 from typing import (
@@ -316,7 +316,7 @@ class AddInheritance(AutodocProcessDocstring):
         ]
 
 
-class CollapseModulePaths(metaclass=ABCMeta):
+class CollapseModulePaths(metaclass=SingletonABCMeta):
     """
     Replace private module paths with their public prefix so that object references
     can be matched by *intersphinx*.
@@ -523,7 +523,7 @@ class CollapseModulePathsInXRef(ObjectDescriptionTransform, CollapseModulePaths)
 
 
 @inheritdoc(match="""[see superclass]""")
-class SkipIndirectImports(AutodocSkipMember):
+class SkipIndirectImports(AutodocSkipMember, metaclass=SingletonABCMeta):
     """
     Skip members imported by a private package.
     """
@@ -546,7 +546,7 @@ class SkipIndirectImports(AutodocSkipMember):
 
 
 @inheritdoc(match="""[see superclass]""")
-class Replace3rdPartyDoc(AutodocProcessDocstring):
+class Replace3rdPartyDoc(AutodocProcessDocstring, metaclass=SingletonABCMeta):
     """
     Replace 3rd party docstrings with a reference to the 3rd party documentation.
 
@@ -789,7 +789,7 @@ class _TypeVarBindings:
 
 
 @inheritdoc(match="""[see superclass]""")
-class ResolveTypeVariables(AutodocBeforeProcessSignature):
+class ResolveTypeVariables(AutodocBeforeProcessSignature, metaclass=SingletonABCMeta):
     """
     Resolve type variables that can be inferred through generic class parameters or
     ``self``/``cls`` special arguments.


### PR DESCRIPTION
Add new Sphinx callbacks:

- `.TrackCurrentClass` to keep track of the current class being processed by *autodoc*
- `.RenamePrivateArguments` to rename private “positional-only” arguments in a function's signature (with two leading underscores) back to their original names in the source code, so that *autodoc* can pick them up correctly.
