### PR TITLE
API: replace ensure_fitted with @fitted_only decorator

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,9 +11,10 @@ Release Notes
 2.1.0
 ~~~~~
 
-- APP: new decorator :obj:`.fitted_only` to mark methods that may only be
+- API: new decorator :obj:`.fitted_only` to mark methods that may only be
   called after their associated object has been fitted using :meth:`.FittableMixin.fit`.
-- API: remove method ``ensure_fitted`` from :class:`.FittableMixin`
+- API: remove method ``ensure_fitted`` from :class:`.FittableMixin`, which is no longer
+  needed due to the new decorator :obj:`.fitted_only`.
 
 
 *pytools* 2.0

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,10 +5,21 @@ Release Notes
 .. |nbsp| unicode:: 0xA0
    :trim:
 
+*pytools* 2.1
+-------------
+
+2.1.0
+~~~~~
+
+- APP: new decorator :obj:`.fitted_only` to mark methods that may only be
+  called after their associated object has been fitted using :meth:`.FittableMixin.fit`.
+- API: remove method ``ensure_fitted`` from :class:`.FittableMixin`
+
+
 *pytools* 2.0
 -------------
 
-*pytools* 2 features enhanced visualisations together with additional API improvements,
+*pytools* 2.0 features enhanced visualisations together with additional API improvements,
 and is now subject to static type checking with |mypy|.
 
 2.0.4

--- a/src/pytools/fit/_fit.py
+++ b/src/pytools/fit/_fit.py
@@ -55,12 +55,41 @@ __tracker = AllTracker(globals())
 class NotFittedError(Exception):
     """
     Raised when a fittable object was expected to be fitted but was not fitted.
+
+    See also :class:`FittableMixin` and the :obj:`fitted_only` decorator.
     """
 
 
 class FittableMixin(Generic[T_Data], metaclass=ABCMeta):
+    # noinspection GrazieInspection
     """
     Mix-in class that supports fitting the object to data.
+
+    See also the :obj:`fitted_only` decorator.
+
+    Usage:
+
+    .. code-block:: python
+
+        class MyFittable(FittableMixin[MyData]):
+            def fit(self, data: MyData) -> "MyFittable":
+                # fit object to data
+                ...
+
+                return self
+
+            def is_fitted(self) -> bool:
+                # Return True if the object is fitted, False otherwise
+                ...
+
+            @fitted_only
+            def some_method(self, ...) -> ...:
+                # This method may only be called if the object is fitted
+                ...
+
+    .. note::
+        This class is not meant to be instantiated directly. Instead, it is
+        meant to be used as a mix-in class for other classes.
     """
 
     @abstractmethod

--- a/src/pytools/fit/_fit.py
+++ b/src/pytools/fit/_fit.py
@@ -1,9 +1,20 @@
 """
 Core implementation of :mod:`pytools.fit`.
 """
+import functools
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 from ..api import AllTracker
 
@@ -13,7 +24,11 @@ log = logging.getLogger(__name__)
 # Exported names
 #
 
-__all__ = ["NotFittedError", "FittableMixin"]
+__all__ = [
+    "NotFittedError",
+    "FittableMixin",
+    "fitted_only",
+]
 
 
 #
@@ -22,6 +37,7 @@ __all__ = ["NotFittedError", "FittableMixin"]
 
 T_Self = TypeVar("T_Self")
 T_Data = TypeVar("T_Data")
+T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
 
 
 #
@@ -66,14 +82,66 @@ class FittableMixin(Generic[T_Data], metaclass=ABCMeta):
         """
         pass
 
-    def ensure_fitted(self) -> None:
-        """
-        Ensure that this object is not fitted.
 
-        :raise pytools.fit.NotFittedError: this object is not fitted
-        """
+@overload
+def fitted_only(__method: T_Callable) -> T_Callable:
+    """[overloaded]"""
+
+
+@overload
+def fitted_only(
+    *,
+    not_fitted_error: Type[Exception],
+) -> Callable[[T_Callable], T_Callable]:
+    """[overloaded]"""
+
+
+def fitted_only(
+    __method: Optional[T_Callable] = None,
+    *,
+    not_fitted_error: Type[Exception] = NotFittedError,
+) -> Union[T_Callable, Callable[[T_Callable], T_Callable]]:
+    # noinspection GrazieInspection
+    """
+    Decorator that ensures that the decorated method is only called if the object is
+    fitted.
+
+    The decorated method must be a method of a class that inherits from
+    :class:`FittableMixin`, or implements a boolean property ``is_fitted``.
+
+    Usage:
+
+    .. code-block:: python
+
+      class MyFittable(FittableMixin):
+          def __init__(self) -> None:
+              self._is_fitted = False
+
+          @fitted_only
+          def my_method(self) -> None:
+              # this method may only be called if the object is fitted
+              ...
+
+          @property
+          def is_fitted(self) -> bool:
+              return self._is_fitted
+
+    :param __method: the method to decorate
+    :param not_fitted_error: the type of exception to raise if the object is not fitted;
+        defaults to :class:`.NotFittedError`
+    :return: the decorated method
+    """
+    if __method is None:
+        return functools.partial(fitted_only, not_fitted_error=not_fitted_error)
+    method: T_Callable = __method
+
+    @functools.wraps(method)
+    def _wrapper(self: FittableMixin[Any], *args: Any, **kwargs: Any) -> Any:
         if not self.is_fitted:
-            raise NotFittedError(f"{type(self).__name__} is not fitted")
+            raise not_fitted_error(f"{type(self).__name__} is not fitted")
+        return method(self, *args, **kwargs)
+
+    return cast(T_Callable, _wrapper)
 
 
 __tracker.validate()

--- a/src/pytools/fit/_fit.py
+++ b/src/pytools/fit/_fit.py
@@ -120,7 +120,7 @@ def fitted_only(__method: T_Callable) -> T_Callable:
 @overload
 def fitted_only(
     *,
-    not_fitted_error: Type[Exception],
+    not_fitted_error: Type[Exception] = NotFittedError,
 ) -> Callable[[T_Callable], T_Callable]:
     """[overloaded]"""
 


### PR DESCRIPTION
Introduce a new decorator `@fitted_only` that ensures that the decorated method is only called if the object is fitted.

The decorated method must be a method of a class that inherits from `FittableMixin`, or implements a boolean property `is_fitted`.

 Usage:
``` python
class MyFittable(FittableMixin):

   def __init__(self) -> None:
       self._is_fitted = False

   @fitted_only
   def my_method(self) -> None:
       # this method may only be called if the object is fitted
       ...

   @property
   def is_fitted(self) -> bool:
       return self._is_fitted
```