### PR TITLE
BUILD: use boa's `mambabuild` as drop-in replacement for `conda-build`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,7 +243,12 @@ stages:
           - script: dir $(Build.SourcesDirectory)
 
           - script: |
-              conda install -y -c conda-forge boa~=0.14 conda-build~=3.24 conda-verify~=3.4 toml~=0.10 flit~=3.6 packaging~=20.9
+              # install micromamba
+              curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+              export MAMBA_ROOT_PREFIX=~/micromamba
+              eval "$(./bin/micromamba shell hook -s posix)"
+
+              mamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -272,6 +272,7 @@ stages:
                 if [ "$BUILD_SYSTEM" = "conda" ] ; then
                   export MAMBA_ROOT_PREFIX=~/micromamba
                   eval "$(./bin/micromamba shell hook -s posix)"
+                  micromamba activate build
                 fi
                 export RUN_PACKAGE_VERSION_TEST=$(project_name)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,7 +247,10 @@ stages:
               curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
               export MAMBA_ROOT_PREFIX=~/micromamba
               eval "$(./bin/micromamba shell hook -s posix)"
-
+              
+              # create and activate a build environment, then install the tools we need
+              micromamba create -n build
+              micromamba activate build
               micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,7 +248,7 @@ stages:
               export MAMBA_ROOT_PREFIX=~/micromamba
               eval "$(./bin/micromamba shell hook -s posix)"
 
-              mamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
+              micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,7 +243,7 @@ stages:
           - script: dir $(Build.SourcesDirectory)
 
           - script: |
-              conda install -y -c anaconda conda-build~=3.21 conda-verify~=3.4 toml~=0.10 flit~=3.6 packaging~=20.9
+              conda install -y -c conda-forge boa~=0.14 conda-build~=3.24 conda-verify~=3.4 toml~=0.10 flit~=3.6 packaging~=20.9
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,7 +269,10 @@ stages:
               targetType: 'inline'
               script: |
                 set -eux
-                if [ "$BUILD_SYSTEM" = "conda" ] ; then eval "$(conda shell.bash hook)" ; fi
+                if [ "$BUILD_SYSTEM" = "conda" ] ; then
+                  export MAMBA_ROOT_PREFIX=~/micromamba
+                  eval "$(./bin/micromamba shell hook -s posix)"
+                fi
                 export RUN_PACKAGE_VERSION_TEST=$(project_name)
 
                 cd $(Build.SourcesDirectory)/$(project_root)

--- a/make.py
+++ b/make.py
@@ -451,7 +451,7 @@ class CondaBuilder(Builder):
         )
 
         os.makedirs(build_path, exist_ok=True)
-        build_cmd = f"conda-build -c conda-forge -c bcg_gamma {recipe_path}"
+        build_cmd = f"conda mambabuild -c conda-forge -c bcg_gamma {recipe_path}"
         log(
             f"Building: {self.project}\n"
             f"Build path: {build_path}\n"


### PR DESCRIPTION
Conda builds can take 30m or more, with most time spent on environment solving.

This PR replaces `conda-build` with *boa*'s `mambabuild` drop-in replacement, taking advantage of mamba's more efficient solver, thus significantly accelerating conda builds.