### PR TITLE
API: resolve forward references in type aliases exported via `__all__`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -8,11 +8,18 @@ Release Notes
 *pytools* 2.1
 -------------
 
+2.1.1
+~~~~~
+
+- API: :class:`.AllTracker` now resolves forward references in type aliases
+  exported via ``__all__``
+
+
 2.1.0
 ~~~~~
 
 - API: new decorator :obj:`.fitted_only` to mark methods that may only be
-  called after their associated object has been fitted using :meth:`.FittableMixin.fit`.
+  called after their associated object has been fitted using :meth:`.FittableMixin.fit`
 - API: remove method ``ensure_fitted`` from :class:`.FittableMixin`, which is no longer
   needed due to the new decorator :obj:`.fitted_only`.
 - API: new Sphinx callback :class:`.TrackCurrentClass` to keep track of the current

--- a/src/pytools/api/_alltracker.py
+++ b/src/pytools/api/_alltracker.py
@@ -188,7 +188,9 @@ class AllTracker:
             if forbid_imported_definitions and obj_module and obj_module != module:
                 raise AssertionError(
                     f"{_qualname(obj)} is exported by module {module} "
-                    f"but defined in module {obj_module}"
+                    f"but defined in module {obj_module}; "
+                    "remove it from __all__, or create the AllTracker with parameter "
+                    "allow_imported_definitions=True"
                 )
 
             # set public module field

--- a/src/pytools/meta/_meta.py
+++ b/src/pytools/meta/_meta.py
@@ -43,7 +43,7 @@ class SingletonMeta(type):
     Singleton classes must not accept any parameters upon instantiation.
     """
 
-    __instance_ref: "Optional[ReferenceType[Any]]"
+    __instance_ref: Optional[ReferenceType]  # type: ignore
 
     def __init__(cls: SingletonMeta, *args: Any, **kwargs: Any) -> None:
         """

--- a/test/test/pytools/test_api.py
+++ b/test/test/pytools/test_api.py
@@ -271,7 +271,7 @@ def test_all_tracker() -> None:
         AssertionError,
         match=(
             r"A is exported by module test\.pytools\.test_api_other but defined in "
-            r"module test\.pytools\.test_api$"
+            r"module test\.pytools\.test_api"
         ),
     ):
         tracker.validate()

--- a/test/test/pytools/test_api.py
+++ b/test/test/pytools/test_api.py
@@ -1,9 +1,10 @@
 """
 Basic test cases for the `pytools.api` module
 """
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import pytest
+from typing_extensions import TypeAlias
 
 from pytools.api import (
     AllTracker,
@@ -18,6 +19,7 @@ from pytools.api import (
 )
 
 PKG_TEST_PYTOOLS_TEST_API = "test.pytools.test_api"
+MyTypeAlias: TypeAlias = Union["str", int]
 
 
 def test_deprecated() -> None:
@@ -190,7 +192,7 @@ def test_all_tracker() -> None:
     # test with defaults, no constant declaration
 
     mock_globals: Dict[str, Any] = dict(
-        __all__=["A", "B"],
+        __all__=["A", "B", "MyTypeAlias"],
         __name__=PKG_TEST_PYTOOLS_TEST_API,
     )
     tracker = AllTracker(mock_globals)
@@ -200,14 +202,16 @@ def test_all_tracker() -> None:
             A=A,
             B=B,
             _C=_C,
+            MyTypeAlias=MyTypeAlias,
         )
     )
     tracker.validate()
 
-    assert tracker.get_tracked() == ["A", "B"]
+    assert tracker.get_tracked() == ["A", "B", "MyTypeAlias"]
     assert tracker.is_tracked("A", A)
     assert tracker.is_tracked("B", B)
     assert not tracker.is_tracked("_C", _C)
+    assert mock_globals["MyTypeAlias"] == Union[str, int]
 
     # test with defaults, with constant declaration
 

--- a/test/test/pytools/test_meta.py
+++ b/test/test/pytools/test_meta.py
@@ -1,0 +1,24 @@
+"""
+Tests for the pytools.meta package
+"""
+from pytools.meta import SingletonABCMeta, SingletonMeta
+
+
+def test_singleton_meta() -> None:
+    """
+    Test the singleton metaclasses
+    """
+
+    class TestSingleton(metaclass=SingletonMeta):
+        """
+        Test class for the singleton metaclass
+        """
+
+    assert TestSingleton() is TestSingleton()
+
+    class TestSingletonABC(metaclass=SingletonABCMeta):
+        """
+        Test class for the singleton ABC metaclass
+        """
+
+    assert TestSingletonABC() is TestSingletonABC()


### PR DESCRIPTION
Exporting type aliases containing forward references, such as
``` python
ClassAOrB: TypeAlias = Union["ClassADefinedBelow", "ClassBDefinedBelow"]
```
could raise an exception because the `AllTracker` would not resolve the forward reference.

This PR enhances the `AllTracker` class to detect and resolve such forward references.