### PR TITLE
FIX: prevent missing font warnings

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,6 +11,11 @@ Release Notes
 *pytools* 2 introduces enhanced visualisations along with additional API improvements,
 and is now subject to static type checking with |mypy|.
 
+2.0.7
+~~~~~
+
+- FIX: prevent `matplot` warnings about missing fonts when rendering drawers using the :class:`.MatplotStyle`
+
 
 2.0.6
 ~~~~~


### PR DESCRIPTION
This PR prevents ``matplotlib`` warnings about missing fonts when rendering drawers using the ``MatplotStyle``