### PR TITLE
change ticklabels to labels

### DIFF
--- a/src/pytools/viz/dendrogram/_style.py
+++ b/src/pytools/viz/dendrogram/_style.py
@@ -218,7 +218,7 @@ class DendrogramMatplotStyle(DendrogramStyle, ColorbarMatplotStyle):
         # set the tick locations and labels
         y_axis = self.ax.yaxis
         y_axis.set_ticks(ticks=list(self._get_ytick_locations(weights=weights)))
-        y_axis.set_ticklabels(labels=names)
+        y_axis.set_ticklabels(names)
 
     def _get_ytick_locations(
         self, *, weights: Sequence[float]

--- a/src/pytools/viz/dendrogram/_style.py
+++ b/src/pytools/viz/dendrogram/_style.py
@@ -218,7 +218,7 @@ class DendrogramMatplotStyle(DendrogramStyle, ColorbarMatplotStyle):
         # set the tick locations and labels
         y_axis = self.ax.yaxis
         y_axis.set_ticks(ticks=list(self._get_ytick_locations(weights=weights)))
-        y_axis.set_ticklabels(ticklabels=names)
+        y_axis.set_ticklabels(labels=names)
 
     def _get_ytick_locations(
         self, *, weights: Sequence[float]


### PR DESCRIPTION
This pull request addresses a minor inconsistency in the set_ticklabels method call within the y_axis configuration. Specifically, it updates the method call from y_axis.set_ticklabels(ticklabels=names) to y_axis.set_ticklabels(labels=names).

https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xticklabels.html
