### PR TITLE
BUILD: update pipeline to use `rattler` for conda builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,19 @@ repos:
         args: [--py310-plus]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
         language: python
         language_version: python310
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         name: flake8
@@ -26,11 +26,11 @@ repos:
         language: python
         language_version: python310
         additional_dependencies:
-          - flake8-comprehensions ~= 3.10
+          - flake8-comprehensions ~= 3.16
         types: [ python ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -40,7 +40,7 @@ repos:
         exclude: condabuild/meta.yaml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         entry: mypy src/ test/ sphinx/
@@ -50,6 +50,6 @@ repos:
         language_version: python310
         pass_filenames: false
         additional_dependencies:
-          - numpy~=2.0
+          - numpy~=2.2
           - pytest
           - packaging

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,7 +255,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=25
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 'packaging>=25'
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 
@@ -354,7 +354,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=25
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 'packaging>=25'
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 
@@ -459,7 +459,7 @@ stages:
               condition: ne(variables.branchName, 'develop')
               script: |
                 set -eux
-                python -m pip install toml~=0.10.2 packaging~=20.9
+                python -m pip install toml~=0.10.2 'packaging>=25'
                 cd $(System.DefaultWorkingDirectory)/pytools
                 python <<EOF
                 from os import environ
@@ -522,7 +522,7 @@ stages:
               script: |
                 set -eux
                 echo "Getting version"
-                pip install packaging~=20.9
+                pip install 'packaging>=25'
                 package_path=$(System.DefaultWorkingDirectory)/$(project_root)/src/$(project_name)
                 export PYTHONPATH=$(System.DefaultWorkingDirectory)/pytools/sphinx/base
                 version=$(python -c "import make_util; print(make_util.get_package_version(package_path='$package_path'))")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ schedules:
     displayName: Nightly full build
     branches:
       include:
-        - 2.1.x
+        - 3.0.x
 
 resources:
   repositories:
@@ -104,7 +104,7 @@ stages:
     jobs:
 
       - job: checkout_and_diff
-        displayName: 'detect changes'
+        displayName: 'detect config changes'
         steps:
           - checkout: self
             fetchDepth: 2
@@ -192,9 +192,7 @@ stages:
 
           - task: PublishCodeCoverageResults@2
             inputs:
-              codeCoverageTool: Cobertura
               summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage.xml'
-              reportDirectory: '$(System.DefaultWorkingDirectory)/htmlcov'
 
   # conda env & tox build test
   # testing matrix of python & sklearn versions
@@ -311,7 +309,7 @@ stages:
         strategy:
           matrix:
             default_dependencies_conda:
-              FACET_V_PYTHON_BUILD: '=3.10'
+              FACET_V_PYTHON_BUILD: '=3.11'
               BUILD_SYSTEM: 'conda'
               PKG_DEPENDENCIES: 'default'
             minimum_dependencies_conda:
@@ -323,7 +321,7 @@ stages:
               BUILD_SYSTEM: 'conda'
               PKG_DEPENDENCIES: 'max'
             default_dependencies_tox:
-              FACET_V_PYTHON_BUILD: '=3.10'
+              FACET_V_PYTHON_BUILD: '=3.11'
               BUILD_SYSTEM: 'tox'
               PKG_DEPENDENCIES: 'default'
             minimum_dependencies_tox:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
               versionSpec: '3.10'
             displayName: 'use Python 3.10'
           - script: |
-              python -m pip install isort~=5.12
+              python -m pip install isort~=6.0
               python -m isort --check --diff .
             displayName: 'Run isort'
       - job:
@@ -65,7 +65,7 @@ stages:
               versionSpec: '3.10'
             displayName: 'use Python 3.10'
           - script: |
-              python -m pip install black~=24.4.2
+              python -m pip install black~=25.1.0
               python -m black --check .
             displayName: 'Run black'
       - job:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ stages:
               versionSpec: '3.10'
             displayName: 'use Python 3.10'
           - script: |
-              python -m pip install flake8~=7.0 flake8-comprehensions~=3.10
+              python -m pip install flake8~=7.3 flake8-comprehensions~=3.16
               python -m flake8 --config tox.ini -v .
             displayName: 'Run flake8'
       - job:
@@ -89,7 +89,7 @@ stages:
           - script: |
               # package dependencies for mypy
               dependencies=(
-                numpy~=2.0
+                numpy~=2.2
                 packaging
                 pytest
               )
@@ -257,7 +257,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=25
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 
@@ -356,7 +356,7 @@ stages:
               # create and activate a build environment, then install the tools we need
               micromamba create -n build
               micromamba activate build
-              micromamba install -y -c conda-forge boa~=0.14 toml~=0.10 flit~=3.6 packaging~=20.9
+              micromamba install -y -c conda-forge rattler-build~=0.44 toml~=0.10 flit~=3.6 packaging~=25
             displayName: 'Install conda-build, flit, toml'
             condition: eq(variables['BUILD_SYSTEM'], 'conda')
 

--- a/condabuild/meta.yaml
+++ b/condabuild/meta.yaml
@@ -1,3 +1,8 @@
+# This file is deprecated and no longer used: we have transitioned to using rattler for
+# building conda packages, and the new build recipe is in recipe.yaml.
+#
+# Keeping this file for reference and historical context.
+
 package:
   name: gamma-pytools
   version: {{ environ.get('FACET_BUILD_PYTOOLS_VERSION') }}
@@ -34,12 +39,10 @@ test:
     - pytools.sphinx
     - pytools.viz
   requires:
-    - pytest ~= 7.1
+    - pytest ~= 8.1
   commands:
     - conda list
-    - python -c 'import pytools;
-                 import os;
-                 assert pytools.__version__ == os.environ["PKG_VERSION"]'
+    - python -c 'import pytools; import os; assert pytools.__version__ == os.environ["PKG_VERSION"]'
     - cd "${FACET_PATH}/pytools"
     - pytest -vs test
 

--- a/condabuild/meta.yaml
+++ b/condabuild/meta.yaml
@@ -39,7 +39,7 @@ test:
     - pytools.sphinx
     - pytools.viz
   requires:
-    - pytest ~= 8.1
+    - pytest ~= 8.2
   commands:
     - conda list
     - python -c 'import pytools; import os; assert pytools.__version__ == os.environ["PKG_VERSION"]'

--- a/condabuild/recipe.yaml
+++ b/condabuild/recipe.yaml
@@ -39,7 +39,7 @@ tests:
         - pytools.viz
   - requirements:
       run:
-        - pytest ~= 8.1
+        - pytest ~= 8.2
     script:
       - conda list
       - "python -c 'import pytools; import os; assert pytools.__version__ == os.environ[\"PKG_VERSION\"]'"

--- a/condabuild/recipe.yaml
+++ b/condabuild/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+package:
+  name: gamma-pytools
+  version: ${{ env.get('FACET_BUILD_PYTOOLS_VERSION') }}
+
+source:
+  git: ../
+
+build:
+  noarch: python
+  script: flit install --deps none
+
+requirements:
+  host:
+    - pip    >=21
+    - python ${{ env.get('FACET_V_PYTHON') }}
+    - numpy  ${{ env.get('FACET_V_NUMPY') }}
+    - flit   =3
+  run:
+    - joblib          ${{ env.get('FACET_V_JOBLIB') }}
+    - matplotlib-base ${{ env.get('FACET_V_MATPLOTLIB') }}
+    - numpy           ${{ env.get('FACET_V_NUMPY') }}
+    - pandas          ${{ env.get('FACET_V_PANDAS') }}
+    - python          ${{ env.get('FACET_V_PYTHON') }}
+    - scipy           ${{ env.get('FACET_V_SCIPY') }}
+    - typing_inspect  ${{ env.get('FACET_V_TYPING_INSPECT') }}
+
+tests:
+  - python:
+      imports:
+        - pytools
+        - pytools.api
+        - pytools.data
+        - pytools.expression
+        - pytools.fit
+        - pytools.parallelization
+        - pytools.sphinx
+        - pytools.viz
+  - requirements:
+      run:
+        - pytest ~= 8.1
+    script:
+      - conda list
+      - "python -c 'import pytools; import os; assert pytools.__version__ == os.environ[\"PKG_VERSION\"]'"
+      - "cd \"${FACET_PATH}/pytools\""
+      - pytest -vs test
+
+about:
+  license: OSL-2.0
+  license_file: LICENSE
+  description: |
+    A collection of generic Python extensions and tools, used across GAMMA's open-source
+    libraries.
+  homepage: https://github.com/BCG-X-Official/pytools
+  repository: https://github.com/BCG-X-Official/pytools
+  documentation: https://bcg-x-official.github.io/pytools/
+

--- a/environment.yml
+++ b/environment.yml
@@ -12,8 +12,8 @@ dependencies:
   - typing_extensions ~= 4.3
   - typing_inspect    ~= 0.9
   # test
-  - pytest     ~= 7.2.1
-  - pytest-cov ~= 4.1.1
+  - pytest     ~= 8.4
+  - pytest-cov ~= 6.2
   # sphinx
   - nbsphinx                 ~= 0.8.9
   - sphinx                   ~= 4.5.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,13 +7,13 @@ dependencies:
   - matplotlib        ~= 3.6
   - numpy             ~= 2.0
   - pandas            ~= 2.0
-  - python            ~= 3.10.14
+  - python            ~= 3.10.18
   - scipy             ~= 1.10
   - typing_extensions ~= 4.3
   - typing_inspect    ~= 0.9
   # test
   - pytest     ~= 7.2.1
-  - pytest-cov ~= 2.12.1
+  - pytest-cov ~= 4.1.1
   # sphinx
   - nbsphinx                 ~= 0.8.9
   - sphinx                   ~= 4.5.0

--- a/make.py
+++ b/make.py
@@ -466,7 +466,7 @@ class CondaBuilder(Builder):
         )
 
         os.makedirs(build_path, exist_ok=True)
-        build_cmd = f"conda mambabuild -c conda-forge {recipe_path}"
+        build_cmd = f"rattler-build build --recipe {recipe_path}"
         log(
             f"Building: {self.project}\n"
             f"Build path: {build_path}\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ typing_inspect = "~=0.7"
 typing_extensions = "~=4.3"
 
 [tool.black]
-required-version = '24.4.2'
+required-version = '25.1.0'
 line-length = 88
 target_version = ['py311']
 include = '\.pyi?$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ classifiers = [
 
 [tool.flit.metadata.requires-extra]
 testing = [
-    "pytest ~= 8.1",
-    "pytest-cov ~= 4.1",
+    "pytest ~= 8.2",
+    "pytest-cov ~= 6.2",
 ]
 docs = [
     "sphinx ~= 4.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ classifiers = [
 
 [tool.flit.metadata.requires-extra]
 testing = [
-    "pytest ~= 7.1",
-    "pytest-cov ~= 2.12",
+    "pytest ~= 8.1",
+    "pytest-cov ~= 4.1",
 ]
 docs = [
     "sphinx ~= 4.5",
@@ -71,7 +71,7 @@ joblib = "~=1.0.1"
 matplotlib = "~=3.6.3"
 numpy = ">=1.23.5,<1.24a"  # cannot use ~= due to conda bug
 pandas = "~=1.5.3"
-python = ">=3.10.14,<3.11a"    # cannot use ~= due to conda bug
+python = ">=3.10.18,<3.11a"    # cannot use ~= due to conda bug
 scipy = "~=1.9.3"
 typing_inspect = "~=0.7.1"
 typing_extensions = "~=4.0.0"

--- a/sphinx/base/conf_base.py
+++ b/sphinx/base/conf_base.py
@@ -61,7 +61,6 @@ def set_config(
 
 
 def _update_intersphinx_mapping(mapping: dict[str, tuple[str, str | None]]) -> None:
-    global intersphinx_mapping
     intersphinx_mapping.update(mapping)
 
 

--- a/src/pytools/api/_api.py
+++ b/src/pytools/api/_api.py
@@ -344,7 +344,9 @@ def validate_type(
         return value
 
     if optional and value is None:
-        return None
+        # We ignore the mypy error here because we know that generic type T
+        # includes None when the value is None.
+        return None  # type: ignore[return-value]
 
     if not isinstance(value, expected_type):
         _raise_type_mismatch(

--- a/src/pytools/viz/color/_color.py
+++ b/src/pytools/viz/color/_color.py
@@ -105,7 +105,7 @@ _COLORMAP_FACET = LinearSegmentedColormap.from_list(
 def _get_property_name(
     # we use a union type here: depending on the type checker, properties
     # will be considered a callable (mypy), or of type property (PyCharm)
-    p: Callable[[ColorScheme], RgbColor] | property
+    p: Callable[[ColorScheme], RgbColor] | property,
 ) -> str:
     # helper function used while setting class attributes of class ColorScheme (below)
     return cast(FunctionType, cast(property, p).fget).__name__

--- a/tox.ini
+++ b/tox.ini
@@ -43,24 +43,21 @@ max-line-length = 88
 
 show-source = true
 
+# W504: line break before binary operator
+# E731: do not assign a lambda expression, use a def
+# E741: ignore not easy to read variables like i l I etc
+# C408: Unnecessary (dict/list/tuple) call - rewrite as a literal
+# Ignores below are added to prevent conflicts with Black formatter
+# E231: Missing whitespace after ',', ';', or ':'
+# E203: space before :
+# W503: line break before binary operator
 ignore =
-    # line break before binary operator
     W504,
-    # do not assign a lambda expression, use a def
     E731,
-    # ignore not easy to read variables like i l I etc
     E741,
-    # Unnecessary (dict/list/tuple) call - rewrite as a literal
     C408,
-    # found modulo formatter (incorrect picks up mod operations)
-    # S001,
-
-    # Ignores below are added to prevent conflicts with Black formatter
-    # Missing whitespace after ',', ';', or ':'
     E231,
-    # space before :
     E203,
-    # line break before binary operator
     W503,
 
 per-file-ignores =


### PR DESCRIPTION
This pull request includes multiple updates to dependencies, build configurations, and code quality tools, along with some minor code adjustments. The most significant changes involve upgrading pre-commit hooks, transitioning to a new conda build system, and updating Python and package dependencies across various configurations.

### Dependency and Tool Upgrades:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L9-R33): Updated versions of `isort`, `black`, `flake8`, `flake8-comprehensions`, and `mypy` to their latest releases. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L9-R33) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L43-R43)
* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L57-R57): Updated Python dependencies (`isort`, `black`, `flake8`, `numpy`) and replaced `boa` with `rattler-build` in the conda build pipeline. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L57-R57) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L260-R258)
* `pyproject.toml` and `environment.yml`: Updated versions of `pytest`, `pytest-cov`, and `python`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L44-R45) [[2]](diffhunk://#diff-9efd195f4e9bfb79ccd456a1d8370fafcc4bcb0b00ea3799222667d2ae818533L10-R16)

### Build System Transition:
* [`make.py`](diffhunk://#diff-6bf738d0dd0f963c9f86b7917b2513277e7b3f78eeea507f809f49bdcad61733L469-R469): Replaced `conda mambabuild` with `rattler-build` for building conda packages.
* [`condabuild/meta.yaml`](diffhunk://#diff-e1c5d28191dba7f4aa6040b732983b0a2b8bad2c98dc6169212f0c2a389ef11cR1-R5): Deprecated in favor of the new `condabuild/recipe.yaml` file for conda package builds. [[1]](diffhunk://#diff-e1c5d28191dba7f4aa6040b732983b0a2b8bad2c98dc6169212f0c2a389ef11cR1-R5) [[2]](diffhunk://#diff-d19109024e024628eba591667a511ad11a68dd3ce63c5cacf66f84128cbc3b2bR1-R58)

### Configuration Updates:
* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L21-R21): Updated branch for nightly builds from `2.1.x` to `3.0.x` and adjusted Python version matrix to include Python 3.11. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L21-R21) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L314-R312)
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R46-L63): Added and clarified ignored linting rules to align with the Black formatter.

### Code Adjustments:
* [`src/pytools/api/_api.py`](diffhunk://#diff-8d68b6ac46826f2ffdcb085803d81aee3a5eca025f5428e9e99ba0e426c2ab05L347-R349): Added a `type: ignore` comment to address a mypy error in a generic type return.
* [`src/pytools/viz/color/_color.py`](diffhunk://#diff-744a4d649f53f71cad36ac66611009ba4a7c3118a9f2e6a950af7bcbbadefc44L108-R108): Minor syntax adjustment to improve type annotations.

These changes collectively enhance the project's dependency management, build process, and code quality, while introducing support for newer Python versions and tools.