### PR TITLE
FIX: support python 3 14

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,25 +3,25 @@ channels:
   - conda-forge
 dependencies:
   # run
-  - joblib            ~= 1.2
-  - matplotlib        ~= 3.6
-  - numpy             ~= 2.0
-  - pandas            ~= 2.0
-  - python            ~= 3.10.18
-  - scipy             ~= 1.10
-  - typing_extensions ~= 4.3
+  - joblib            ~= 1.5
+  - matplotlib        ~= 3.10
+  - numpy             ~= 2.4
+  - pandas            ~= 2.3
+  - python            ~= 3.14
+  - scipy             ~= 1.17
+  - typing_extensions ~= 4.15
   - typing_inspect    ~= 0.9
   # test
   - pytest     ~= 8.4
-  - pytest-cov ~= 6.2
+  - pytest-cov ~= 6.3
   # sphinx
-  - nbsphinx                 ~= 0.8.9
-  - sphinx                   ~= 4.5.0
-  - sphinx-autodoc-typehints ~= 1.19.2
-  - pydata-sphinx-theme      ~= 0.8.1
+  - nbsphinx                 ~= 0.8
+  - sphinx                   ~= 9.1
+  - sphinx-autodoc-typehints ~= 1.19
+  - pydata-sphinx-theme      ~= 0.8
   # notebooks
-  - ipywidgets ~= 8.0
-  - jupyterlab ~= 3.5
-  - openpyxl   ~= 3.0
-  - seaborn    ~= 0.12
-  - tableone   ~= 0.7
+  - ipywidgets ~= 8.1
+  - jupyterlab ~= 4.5
+  - openpyxl   ~= 3.1
+  - seaborn    ~= 0.13
+  - tableone   ~= 0.9

--- a/src/pytools/api/_alltracker.py
+++ b/src/pytools/api/_alltracker.py
@@ -228,9 +228,7 @@ class AllTracker:
         )
         # get the type hints for the class and return the evaluated type alias
         # from the dummy field
-        alias_resolved = get_type_hints(cls, globalns=self._globals)[dummy_field]
-        alias_resolved.__module__ = self._module
-        return alias_resolved
+        return get_type_hints(cls, globalns=self._globals)[dummy_field]
 
     def __getitem__(self, name: str) -> Any:
         # get a tracked item by name

--- a/src/pytools/api/_alltracker.py
+++ b/src/pytools/api/_alltracker.py
@@ -173,7 +173,14 @@ class AllTracker:
                         f"exporting a global constant is not permitted: {obj!r}"
                     )
 
-            if forbid_imported_definitions and obj_module and obj_module != module:
+            if (
+                forbid_imported_definitions
+                and obj_module
+                and obj_module != module
+                # Special case: special types such as `Union` can be exported as part
+                # of type aliases, so we allow them to be imported from other modules
+                and obj_module != "typing"
+            ):
                 raise AssertionError(
                     f"{_qualname(obj)} is exported by module {module} "
                     f"but defined in module {obj_module}; "

--- a/src/pytools/api/_alltracker.py
+++ b/src/pytools/api/_alltracker.py
@@ -6,9 +6,14 @@ import logging
 import re
 from collections.abc import Callable, Collection, Iterable
 from types import FunctionType
-from typing import Any, TypeVar, get_type_hints
+from typing import (
+    Any,
+    TypeVar,
+    get_args,
+    get_type_hints,
+)
 
-from typing_inspect import get_args, is_forward_ref
+from typing_inspect import is_forward_ref
 
 log = logging.getLogger(__name__)
 

--- a/src/pytools/sphinx/util/_util.py
+++ b/src/pytools/sphinx/util/_util.py
@@ -256,8 +256,7 @@ class AddInheritance(AutodocProcessDocstring):
 
         else:
             generic_args = [
-                self._class_name_with_generics(arg)
-                for arg in typing_inspect.get_args(cls, evaluate=True)
+                self._class_name_with_generics(arg) for arg in typing.get_args(cls)
             ]
 
             generic_arg_str = f" [{', '.join(generic_args)}]" if generic_args else ""
@@ -284,12 +283,9 @@ class AddInheritance(AutodocProcessDocstring):
     def _get_generics(self, child_class: type) -> list[str]:
         return list(
             itertools.chain.from_iterable(
-                (
-                    self._typevar_name(arg)
-                    for arg in typing_inspect.get_args(base, evaluate=True)
-                )
+                (self._typevar_name(arg) for arg in typing.get_args(base))
                 for base in _get_generic_bases(child_class)
-                if typing_inspect.get_origin(base) is Generic
+                if typing.get_origin(base) is Generic
             )
         )
 
@@ -631,7 +627,7 @@ def _get_bases(subclass: type, include_subclass: bool) -> Generator[type]:
 
     def _inner(_subclass: type, _include_subclass: bool) -> Generator[type]:
         # ensure we have the non-generic origin class
-        _subclass = typing_inspect.get_origin(_subclass) or _subclass
+        _subclass = typing.get_origin(_subclass) or _subclass
 
         if _subclass in visited_classes:
             return
@@ -652,7 +648,7 @@ def _get_bases(subclass: type, include_subclass: bool) -> Generator[type]:
         # hidden classes
         for base in base_classes:
             # exclude object and Generic types
-            if base is object or typing_inspect.get_origin(base) is Generic:
+            if base is object or typing.get_origin(base) is Generic:
                 continue
 
             # exclude protected classes
@@ -668,7 +664,7 @@ def _get_bases(subclass: type, include_subclass: bool) -> Generator[type]:
 
 def _get_minimal_bases(class_: type) -> list[type]:
     bases_with_origin = [
-        (base, typing_inspect.get_origin(base) or base)
+        (base, typing.get_origin(base) or base)
         for base in set(_get_bases(class_, include_subclass=False))
     ]
     return [
@@ -696,7 +692,7 @@ def _class_attr(cls: Any, attr: list[str]) -> Any:
         # if the attribute is not defined, this class is likely to have generic
         # arguments, so we re-try recursively with the origin (unless the origin
         # is the class itself to avoid infinite recursion)
-        cls_origin = typing_inspect.get_origin(_cls)
+        cls_origin = typing.get_origin(_cls)
         if cls_origin is not None and cls_origin != _cls:
             return _get_attr(cls_origin)
         else:
@@ -754,7 +750,7 @@ class _TypeVarBindings:
         # if arg cls has generic type parameters, it will have a corresponding
         cls_origin: type[Any] | None = None
         if typing_inspect.is_generic_type(cls):
-            cls_origin = typing_inspect.get_origin(cls)
+            cls_origin = typing.get_origin(cls)
 
         class_bindings: dict[TypeVar, type[Any] | TypeVar]
         if cls_origin:
@@ -762,7 +758,7 @@ class _TypeVarBindings:
                 param: subclass_bindings.get(arg, arg) if subclass_bindings else arg
                 for param, arg in zip(
                     typing_inspect.get_parameters(cls_origin),
-                    typing_inspect.get_args(cls),
+                    typing.get_args(cls),
                 )
             }
             cls = cls_origin
@@ -871,9 +867,9 @@ class ResolveTypeVariables(AutodocBeforeProcessSignature, metaclass=SingletonABC
                     _, arg_0_type = signature_original_items[0]
                     if (
                         typing_inspect.is_generic_type(arg_0_type)
-                        and typing_inspect.get_origin(arg_0_type) is type
+                        and typing.get_origin(arg_0_type) is type
                     ):
-                        arg_0_type_args = typing_inspect.get_args(arg_0_type)
+                        arg_0_type_args = typing.get_args(arg_0_type)
                         if len(arg_0_type_args) == 1 and typing_inspect.is_typevar(
                             arg_0_type_args[0]
                         ):
@@ -1234,7 +1230,7 @@ def _substitute_generic_type_arguments(
 ) -> type[Any] | TypeVar:
     # dynamically resolve type variables inside nested type expressions
     type_args: tuple[list[type[Any] | TypeVar] | type[Any] | TypeVar, ...] = (
-        typing_inspect.get_args(type_expression)
+        typing.get_args(type_expression)
     )
 
     if type_args:
@@ -1263,8 +1259,10 @@ def _copy_generic_type_with_arguments(
     # create a copy of the given type expression, replacing its type arguments with
     # the given new arguments
 
-    origin = typing_inspect.get_origin(type_expression)
-    assert origin is not None
+    origin = typing.get_origin(type_expression)
+    assert (
+        origin is not None
+    ), f"expected a generic type expression, got {type_expression!r}"
 
     try:
         copy_with: Callable[

--- a/src/pytools/typing/_typing.py
+++ b/src/pytools/typing/_typing.py
@@ -295,7 +295,7 @@ def get_generic_instance(subclass: type, base: type) -> list[type]:
                     bindings=base_bindings,
                 )
 
-    if ti.get_origin(base) is not None and get_args(base):
+    if typing.get_origin(base) is not None and get_args(base):
         raise TypeError(f"arg base must not be a generic instance, but got {base}")
 
     if not issubclass(get_origin(subclass) or subclass, base):
@@ -346,7 +346,9 @@ def get_generic_bases(*, generic_instance: type) -> tuple[type, ...]:
         )
 
         return (
-            special_generic_base[ti.get_args(generic_instance)],  # type: ignore[index]
+            special_generic_base[  # type: ignore[index]
+                typing.get_args(generic_instance)
+            ],
         )
 
     # The origin is not a generic alias


### PR DESCRIPTION
This pull request primarily updates the codebase to use `typing.get_args` and `typing.get_origin` from the Python standard library instead of `typing_inspect.get_args` and `typing_inspect.get_origin`. This change is required for compatibility with Python 3.14 and reduces external dependencies.

Additionally, it updates several dependencies in `environment.yml` to more recent versions and makes a minor logic improvement in type alias validation.

Dependency updates:

* Updated core dependencies in `environment.yml` to newer versions, including `joblib`, `matplotlib`, `numpy`, `pandas`, `python`, `scipy`, and `typing_extensions`. Also updated development and documentation dependencies such as `pytest-cov`, `sphinx`, `jupyterlab`, `openpyxl`, `seaborn`, and `tableone`.

Refactoring to use standard typing utilities:

* Replaced all usages of `typing_inspect.get_args` and `typing_inspect.get_origin` with `typing.get_args` and `typing.get_origin` in `src/pytools/sphinx/util/_util.py` and `src/pytools/typing/_typing.py`, improving compatibility with recent Python versions. [[1]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L259-R259) [[2]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L287-R288) [[3]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L634-R630) [[4]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L655-R651) [[5]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L671-R667) [[6]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L699-R695) [[7]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L757-R761) [[8]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L874-R872) [[9]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L1237-R1233) [[10]](diffhunk://#diff-aa66ccb87d7160f745d0ccca3060487efe05a9ef8f2427ee102a4cc9d49fec57L1266-R1265) [[11]](diffhunk://#diff-267ef1cd3547ccfd5a7ec5625d2eda83f60c93c68cb42a716822727feffe2016L298-R298) [[12]](diffhunk://#diff-267ef1cd3547ccfd5a7ec5625d2eda83f60c93c68cb42a716822727feffe2016L349-R351)

* Updated imports in `src/pytools/api/_alltracker.py` to import `get_args` from the standard library's `typing` module instead of `typing_inspect`.

Logic improvements:

* Improved type alias validation in `src/pytools/api/_alltracker.py` by allowing special types from the `typing` module to be exported as type aliases, even if imported from another module.
* Removed unnecessary assignment of `__module__` when evaluating type aliases in `_evaluate_type_alias`